### PR TITLE
MQTT auth, fixed error handling, less strict json parsing

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -2,6 +2,9 @@
 mqtt:
   # The MQTT broker to connect to
   server: tcp://127.0.0.1:1883
+  # Optional: Username and Password for authenticating with the MQTT Server
+  # user: bob
+  # password: happylittleclouds
   # The Topic path to subscripe to. Actually this will become `$topic_path/+`
   topic_path: v1/devices/me
   # The MQTT QoS level

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,8 @@ type CacheConfig struct {
 type MQTTConfig struct {
 	Server    string `yaml:"server"`
 	TopicPath string `yaml:"topic_path"`
+	User      string `yaml:"user"`
+	Password  string `yaml:"password"`
 	QoS       byte   `yaml:"qos"`
 }
 


### PR DESCRIPTION
- Added MQTT username / password configuration options.
- Fixed blocking error channel 
- JSON Payload value types are no longer required to be numbers. Once mapped to a metric type the value will be checked before storing the metric.
