### PR TITLE
fixed wrong cache behavior (was always 2 minutes)

### DIFF
--- a/cmd/mqtt2prometheus.go
+++ b/cmd/mqtt2prometheus.go
@@ -49,7 +49,7 @@ func main() {
 	mqttClientOptions.SetUsername(cfg.MQTT.User)
 	mqttClientOptions.SetPassword(cfg.MQTT.Password)
 
-	collector := metrics.NewCollector(2*time.Minute, cfg.Metrics)
+	collector := metrics.NewCollector(cfg.Cache.Timeout*time.Minute, cfg.Metrics)
 	ingest := metrics.NewIngest(collector, cfg.Metrics)
 
 	errorChan := make(chan error,1)

--- a/cmd/mqtt2prometheus.go
+++ b/cmd/mqtt2prometheus.go
@@ -49,7 +49,7 @@ func main() {
 	mqttClientOptions.SetUsername(cfg.MQTT.User)
 	mqttClientOptions.SetPassword(cfg.MQTT.Password)
 
-	collector := metrics.NewCollector(cfg.Cache.Timeout*time.Minute, cfg.Metrics)
+	collector := metrics.NewCollector(cfg.Cache.Timeout, cfg.Metrics)
 	ingest := metrics.NewIngest(collector, cfg.Metrics)
 
 	errorChan := make(chan error,1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,9 +2,8 @@ package config
 
 import (
 	"time"
-
+        "log"
 	"io/ioutil"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v2"
 )
@@ -19,13 +18,13 @@ var MQTTConfigDefaults = MQTTConfig{
 }
 
 var CacheConfigDefaults = CacheConfig{
-	Timeout: 2 + time.Minute,
+	Timeout: 1,
 }
 
 type Config struct {
 	Metrics []MetricConfig `yaml:"metrics"`
 	MQTT    *MQTTConfig    `yaml:"mqtt,omitempty"`
-	Cache   *CacheConfig   `yaml:"timeout,omitempty"`
+	Cache   *CacheConfig   `yaml:"cache,omitempty"`
 }
 
 type CacheConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ var MQTTConfigDefaults = MQTTConfig{
 }
 
 var CacheConfigDefaults = CacheConfig{
-	Timeout: 2 + time.Minute,
+	Timeout: 2 * time.Minute,
 }
 
 type Config struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"time"
-        "log"
 	"io/ioutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v2"
@@ -18,7 +17,7 @@ var MQTTConfigDefaults = MQTTConfig{
 }
 
 var CacheConfigDefaults = CacheConfig{
-	Timeout: 1,
+	Timeout: 2,
 }
 
 type Config struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ var MQTTConfigDefaults = MQTTConfig{
 }
 
 var CacheConfigDefaults = CacheConfig{
-	Timeout: 2,
+	Timeout: 2 + time.Minute,
 }
 
 type Config struct {


### PR DESCRIPTION
Hi,
there was a problem that the cache always lasted 2 minutes, regardless of the setting in the config file. The reason was a bug in the config.go and a bug in the mqtt2prometheus.go. With the fix the "timeout" value from the config file is now reflected in the behavior of the exporter.