### PR TITLE
Parse more value types

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -11,7 +11,7 @@ mqtt:
   qos: 0
 cache:
   # Timeout. Each received metric will be presented for this time if no update is send via MQTT
-  timeout: 2min
+  timeout: 2m
 # This is a list of valid metrics. Only metrics listed here will be exported
 metrics:
     # The name of the metric in prometheus
@@ -47,3 +47,22 @@ metrics:
     # A map of string to string for constant labels. This labels will be attached to every prometheus metric
     const_labels:
       sensor_type: dht22
+  - prom_name: state
+    # The name of the metric in a MQTT JSON message
+    mqtt_name: state
+    # The prometheus help text for this metric
+    help: Light state
+    # The prometheus type for this metric. Valid values are: "gauge" and "counter"
+    type: gauge
+    # A map of string to string for constant labels. This labels will be attached to every prometheus metric
+    const_labels:
+      sensor_type: ikea
+    # When specified, enables mapping between string values to metric values.
+    string_value_mapping:
+      # A map of string to metric value.
+      map:
+        off: 0
+        low: 0
+      # Metric value to use if a match cannot be found in the map above.
+      # If not specified, parsing error will occur.
+      error_value: 1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,7 +49,7 @@ type MetricConfig struct {
 	StringValueMapping *StringValueMappingConfig `yaml:"string_value_mapping"`
 }
 
-// StringValueMappingConfig defines the mapping between from string to float
+// StringValueMappingConfig defines the mapping from string to float
 type StringValueMappingConfig struct {
 	// ErrorValue is used when no mapping is found in Map
 	ErrorValue *float64           `yaml:"error_value"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"time"
 	"io/ioutil"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v2"
 )
@@ -40,11 +41,19 @@ type MQTTConfig struct {
 
 // Metrics Config is a mapping between a metric send on mqtt to a prometheus metric
 type MetricConfig struct {
-	PrometheusName string            `yaml:"prom_name"`
-	MQTTName       string            `yaml:"mqtt_name"`
-	Help           string            `yaml:"help"`
-	ValueType      string            `yaml:"type"`
-	ConstantLabels map[string]string `yaml:"const_labels"`
+	PrometheusName     string                    `yaml:"prom_name"`
+	MQTTName           string                    `yaml:"mqtt_name"`
+	Help               string                    `yaml:"help"`
+	ValueType          string                    `yaml:"type"`
+	ConstantLabels     map[string]string         `yaml:"const_labels"`
+	StringValueMapping *StringValueMappingConfig `yaml:"string_value_mapping"`
+}
+
+// StringValueMappingConfig defines the mapping between from string to float
+type StringValueMappingConfig struct {
+	// ErrorValue is used when no mapping is found in Map
+	ErrorValue *float64           `yaml:"error_value"`
+	Map        map[string]float64 `yaml:"map"`
 }
 
 func (mc *MetricConfig) PrometheusDescription() *prometheus.Desc {

--- a/pkg/metrics/ingest.go
+++ b/pkg/metrics/ingest.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"regexp"
 	"strconv"
 
 	"github.com/eclipse/paho.mqtt.golang"
@@ -18,8 +17,6 @@ type Ingest struct {
 	collector     Collector
 	MessageMetric *prometheus.CounterVec
 }
-
-var validNumber = regexp.MustCompile(`^[0-9.]+$`)
 
 func NewIngest(collector Collector, metrics []config.MetricConfig) *Ingest {
 	valid := make(map[string]config.MetricConfig)


### PR DESCRIPTION
Various sensors have string attributes such as "state" which are still
useful to track as metrics. For example, state may be "on" or "off".
These can be showen as 1 and 0 and be used to trigger alerts.