### PR TITLE
Sensor name filtering

### DIFF
--- a/cmd/mqtt2prometheus.go
+++ b/cmd/mqtt2prometheus.go
@@ -1,17 +1,19 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
-	"flag"
+
 	"github.com/eclipse/paho.mqtt.golang"
-	"github.com/hikhvar/mqtt2prometheus/pkg/metrics"
-	"github.com/hikhvar/mqtt2prometheus/pkg/mqttclient"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"fmt"
+
 	"github.com/hikhvar/mqtt2prometheus/pkg/config"
+	"github.com/hikhvar/mqtt2prometheus/pkg/metrics"
+	"github.com/hikhvar/mqtt2prometheus/pkg/mqttclient"
 )
 
 var (
@@ -51,7 +53,7 @@ func main() {
 	collector := metrics.NewCollector(cfg.Cache.Timeout, cfg.Metrics)
 	ingest := metrics.NewIngest(collector, cfg.Metrics)
 
-	errorChan := make(chan error,1)
+	errorChan := make(chan error, 1)
 
 	err = mqttclient.Subscribe(mqttClientOptions, mqttclient.SubscribeOptions{
 		Topic:             cfg.MQTT.TopicPath + "/+",

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -47,9 +47,12 @@ metrics:
     # A map of string to string for constant labels. This labels will be attached to every prometheus metric
     const_labels:
       sensor_type: dht22
+    # The name of the metric in prometheus
   - prom_name: state
     # The name of the metric in a MQTT JSON message
     mqtt_name: state
+    # Regular expression to only match sensors with the given name pattern
+    sensor_name_filter: "^.*-light$"
     # The prometheus help text for this metric
     help: Light state
     # The prometheus type for this metric. Valid values are: "gauge" and "counter"


### PR DESCRIPTION
Adds a new config option `sensor_name_filter` which is a regular expression. This is useful for when different types of sensors present different metrics under the same metric name.