### PR TITLE
Support tasmota

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,27 +8,26 @@ publish the received messages as prometheus metrics. I wrote this exporter to pu
 metrics from small embedded sensors based on the NodeMCU to prometheus. The used arduino scetch can be found in the [dht22tomqtt](https://github.com/hikhvar/dht22tomqtt) repository.
 
 ## Assumptions about Messages and Topics
-This exporter makes some assumptions about the message format and MQTT topics. This exporter assumes that each
-client publish the metrics into a dedicated topic. The last level topic becomes the `sensor` label in prometheus.
-This exporter assume that the message are JSON objects with only float fields. The golang type for the messages is: 
+This exporter makes some assumptions about the MQTT topics. This exporter assumes that each
+client publish the metrics into a dedicated topic. The regular expression ìn the configuration field `mqtt.device_id_regex`
+defines how to extract the device ID from the MQTT topic. This allow an arbitrary place of the device ID in the mqtt topic.
+For example the [tasmota](https://github.com/arendst/Tasmota) firmware pushes the telemetry data to the topics `tele/<deviceid>/SENSOR`.
 
-```go
-type MQTTPayload map[string]float64
-```
-
-For example the message
-
+Let us assume the default configuration from [#ConfigFile]. A sensor publishes the following message
 ```json
-{"temperature":23.20,"humidity":51.60,"heat_index":22.92}
+{"temperature":23.20,"humidity":51.60, "computed": {"heat_index":22.92} }
 ```
 
-published to the MQTT topic `devices/me/livingroom` becomes the following prometheus metrics:
+to the MQTT topic `devices/me/livingroom`. This message becomes the following prometheus metrics:
 
 ```text
-temperature{sensor="livingroom"} 23.2
-heat_index{sensor="livingroom"} 22.92
-humidity{sensor="livingroom"} 51.6
+temperature{sensor="livingroom",topic="devices/me/livingroom"} 23.2
+heat_index{sensor="livingroom",topic="devices/me/livingroom"} 22.92
+humidity{sensor="livingroom",topic="devices/me/livingroom"} 51.6
 ```
+
+### Tasmota
+An example configuration for the tasmota based Gosund SP111 device is given in [examples/gosund_sp111.yaml](examples/gosund_sp111.yaml).
 
 ## Build
 
@@ -85,18 +84,23 @@ The config file can look like this:
 mqtt:
   # The MQTT broker to connect to
   server: tcp://127.0.0.1:1883
-  # The Topic path to subscripe to. Actually this will become `$topic_path/+`
-  topic_path: v1/devices/me
+  # The Topic path to subscripe to. Be aware that you have to specify the wildcard. 
+  topic_path: v1/devices/me/+
+  # Optional: Regular expression to extract the device ID from the topic path. The default regular expression, assumes
+  # that the last "element" of the topic_path is the device id.
+  # The regular expression must contain a named capture group with the name deviceid
+  # For example the expression for tasamota based sensors is "tele/(?P<deviceid>.*)/.*"
+  device_id_regex: "(.*/)?(?P<deviceid>.*)"
   # The MQTT QoS level
   qos: 0
 cache:
   # Timeout. Each received metric will be presented for this time if no update is send via MQTT
-  timeout: 2min
+  timeout: 24h
 # This is a list of valid metrics. Only metrics listed here will be exported
 metrics:
     # The name of the metric in prometheus
   - prom_name: temperature_celsius
-    # The name of the metric in a MQTT JSON message
+    # The name of the metric in a MQTT JSON message. This can be an arbitrary gojsonq path.
     mqtt_name: temperature
     # The prometheus help text for this metric
     help: DHT22 temperature reading
@@ -118,8 +122,8 @@ metrics:
       sensor_type: dht22
     # The name of the metric in prometheus
   - prom_name: heat_index
-    # The name of the metric in a MQTT JSON message
-    mqtt_name: heat_index
+    # The name of the metric in a MQTT JSON message. Here a nested field.
+    mqtt_name: computed.heat_index
     # The prometheus help text for this metric
     help: DHT22 heatIndex calculation
     # The prometheus type for this metric. Valid values are: "gauge" and "counter"

--- a/cmd/mqtt2prometheus.go
+++ b/cmd/mqtt2prometheus.go
@@ -51,7 +51,7 @@ func main() {
 	mqttClientOptions.SetPassword(cfg.MQTT.Password)
 
 	collector := metrics.NewCollector(cfg.Cache.Timeout, cfg.Metrics)
-	ingest := metrics.NewIngest(collector, cfg.Metrics)
+	ingest := metrics.NewIngest(collector, cfg.Metrics, cfg.MQTT.DeviceIDRegex)
 
 	errorChan := make(chan error, 1)
 

--- a/cmd/mqtt2prometheus.go
+++ b/cmd/mqtt2prometheus.go
@@ -57,7 +57,7 @@ func main() {
 
 	for {
 		err = mqttclient.Subscribe(mqttClientOptions, mqttclient.SubscribeOptions{
-			Topic:             cfg.MQTT.TopicPath + "/+",
+			Topic:             cfg.MQTT.TopicPath,
 			QoS:               cfg.MQTT.QoS,
 			OnMessageReceived: ingest.SetupSubscriptionHandler(errorChan),
 		})

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -6,7 +6,7 @@ mqtt:
   # user: bob
   # password: happylittleclouds
   # The Topic path to subscripe to.
-  topic_path: v1/devices/me
+  topic_path: v1/devices/me/+
   # Optional: Regular expression to extract the device ID from the topic path. The default regular expression, assumes
   # that the last "element" of the topic_path is the device id.
   # The regular expression must contain a named capture group with the name deviceid

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -7,6 +7,11 @@ mqtt:
   # password: happylittleclouds
   # The Topic path to subscripe to. Actually this will become `$topic_path/+`
   topic_path: v1/devices/me
+  # Optional: Regular expression to extract the device ID from the topic path. The default regular expression, assumes
+  # that the last "element" of the topic_path is the device id.
+  # The regular expression must contain a named capture group with the name deviceid
+  # For example the expression for tasamota based sensors is "tele/(?P<deviceid>.*)/.*"
+  # device_id_regex: "(.*/)?(?P<deviceid>.*)"
   # The MQTT QoS level
   qos: 0
 cache:

--- a/examples/gosund_sp111.yaml
+++ b/examples/gosund_sp111.yaml
@@ -22,69 +22,27 @@ cache:
 # This is a list of valid metrics. Only metrics listed here will be exported
 metrics:
   # The name of the metric in prometheus
-  - prom_name: consumed_energy_total_kilowatthours
+  - prom_name: consumed_energy_kilowatthours_total
     mqtt_name: "ENERGY.Total"
     help: "total measured kilowatthours since flash"
     type: counter
-  - prom_name: voltage_volt
+  - prom_name: voltage_volts
     mqtt_name: "ENERGY.Voltage"
     help: "Currently measured voltage"
     type: gauge
-  - prom_name: current_ampere
+  - prom_name: current_amperes
     mqtt_name: "ENERGY.Current"
     help: "Currently measured current"
     type: gauge
-  - prom_name: temperature
-    # The name of the metric in a MQTT JSON message
-    mqtt_name: temperature
-    # The prometheus help text for this metric
-    help: DHT22 temperature reading
-    # The prometheus type for this metric. Valid values are: "gauge" and "counter"
+  - prom_name: power_watts
+    mqtt_name: "ENERGY.Power"
+    help: "Currently measured power"
     type: gauge
-    # A map of string to string for constant labels. This labels will be attached to every prometheus metric
-    const_labels:
-      sensor_type: dht22
-    # The name of the metric in prometheus
-  - prom_name: humidity
-    # The name of the metric in a MQTT JSON message
-    mqtt_name: humidity
-    # The prometheus help text for this metric
-    help: DHT22 humidity reading
-    # The prometheus type for this metric. Valid values are: "gauge" and "counter"
+  - prom_name: apparent_power_watt
+    mqtt_name: "ENERGY.ApparentPower"
+    help: "Currently apparent power"
     type: gauge
-    # A map of string to string for constant labels. This labels will be attached to every prometheus metric
-    const_labels:
-      sensor_type: dht22
-    # The name of the metric in prometheus
-  - prom_name: heat_index
-    # The name of the metric in a MQTT JSON message
-    mqtt_name: heat_index
-    # The prometheus help text for this metric
-    help: DHT22 heatIndex calculation
-    # The prometheus type for this metric. Valid values are: "gauge" and "counter"
+  - prom_name: reactive_power_watt
+    mqtt_name: "ENERGY.ReactivePower"
+    help: "Currently reactive power"
     type: gauge
-    # A map of string to string for constant labels. This labels will be attached to every prometheus metric
-    const_labels:
-      sensor_type: dht22
-    # The name of the metric in prometheus
-  - prom_name: state
-    # The name of the metric in a MQTT JSON message
-    mqtt_name: state
-    # Regular expression to only match sensors with the given name pattern
-    sensor_name_filter: "^.*-light$"
-    # The prometheus help text for this metric
-    help: Light state
-    # The prometheus type for this metric. Valid values are: "gauge" and "counter"
-    type: gauge
-    # A map of string to string for constant labels. This labels will be attached to every prometheus metric
-    const_labels:
-      sensor_type: ikea
-    # When specified, enables mapping between string values to metric values.
-    string_value_mapping:
-      # A map of string to metric value.
-      map:
-        off: 0
-        low: 0
-      # Metric value to use if a match cannot be found in the map above.
-      # If not specified, parsing error will occur.
-      error_value: 1

--- a/examples/gosund_sp111.yaml
+++ b/examples/gosund_sp111.yaml
@@ -1,17 +1,17 @@
 # Settings for the MQTT Client. Currently only these three are supported
 mqtt:
   # The MQTT broker to connect to
-  server: tcp://127.0.0.1:1883
+  server: tcp://192.168.1.11:1883
   # Optional: Username and Password for authenticating with the MQTT Server
   # user: bob
   # password: happylittleclouds
-  # The Topic path to subscripe to.
-  topic_path: v1/devices/me
+  # The Topic path to subscripe to. Actually this will become `$topic_path/+`
+  topic_path: tele/+/SENSOR
   # Optional: Regular expression to extract the device ID from the topic path. The default regular expression, assumes
   # that the last "element" of the topic_path is the device id.
   # The regular expression must contain a named capture group with the name deviceid
   # For example the expression for tasamota based sensors is "tele/(?P<deviceid>.*)/.*"
-  # device_id_regex: "(.*/)?(?P<deviceid>.*)"
+  device_id_regex: "tele/(?P<deviceid>.*)/SENSOR"
   # The MQTT QoS level
   qos: 0
 cache:
@@ -21,7 +21,19 @@ cache:
   timeout: 24h
 # This is a list of valid metrics. Only metrics listed here will be exported
 metrics:
-    # The name of the metric in prometheus
+  # The name of the metric in prometheus
+  - prom_name: consumed_energy_total_kilowatthours
+    mqtt_name: "ENERGY.Total"
+    help: "total measured kilowatthours since flash"
+    type: counter
+  - prom_name: voltage_volt
+    mqtt_name: "ENERGY.Voltage"
+    help: "Currently measured voltage"
+    type: gauge
+  - prom_name: current_ampere
+    mqtt_name: "ENERGY.Current"
+    help: "Currently measured current"
+    type: gauge
   - prom_name: temperature
     # The name of the metric in a MQTT JSON message
     mqtt_name: temperature

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/prometheus/procfs v0.0.11
+	github.com/thedevsaddam/gojsonq v2.3.0+incompatible // indirect
+	github.com/thedevsaddam/gojsonq/v2 v2.5.2
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
 	gopkg.in/yaml.v2 v2.2.5
 )

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,11 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/thedevsaddam/gojsonq v1.9.1 h1:zQulEP43nwmq5EKrNWyIgJVbqDeMdC1qzXM/f5O15a0=
+github.com/thedevsaddam/gojsonq v2.3.0+incompatible h1:i2lFTvGY4LvoZ2VUzedsFlRiyaWcJm3Uh6cQ9+HyQA8=
+github.com/thedevsaddam/gojsonq v2.3.0+incompatible/go.mod h1:RBcQaITThgJAAYKH7FNp2onYodRz8URfsuEGpAch0NA=
+github.com/thedevsaddam/gojsonq/v2 v2.5.2 h1:CoMVaYyKFsVj6TjU6APqAhAvC07hTI6IQen8PHzHYY0=
+github.com/thedevsaddam/gojsonq/v2 v2.5.2/go.mod h1:bv6Xa7kWy82uT0LnXPE2SzGqTj33TAEeR560MdJkiXs=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,7 +115,7 @@ type StringValueMappingConfig struct {
 
 func (mc *MetricConfig) PrometheusDescription() *prometheus.Desc {
 	return prometheus.NewDesc(
-		mc.PrometheusName, mc.Help, []string{"sensor"}, mc.ConstantLabels,
+		mc.PrometheusName, mc.Help, []string{"sensor", "topic"}, mc.ConstantLabels,
 	)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,12 +22,12 @@ var CacheConfigDefaults = CacheConfig{
 	Timeout: 2 * time.Minute,
 }
 
-type RegexpFilter struct {
+type Regexp struct {
 	r       *regexp.Regexp
 	pattern string
 }
 
-func (rf *RegexpFilter) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (rf *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var pattern string
 	if err := unmarshal(&pattern); err != nil {
 		return err
@@ -41,11 +41,11 @@ func (rf *RegexpFilter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func (rf *RegexpFilter) MarshalYAML() (interface{}, error) {
+func (rf *Regexp) MarshalYAML() (interface{}, error) {
 	return rf.pattern, nil
 }
 
-func (rf *RegexpFilter) Match(s string) bool {
+func (rf *Regexp) Match(s string) bool {
 	return rf.r == nil || rf.r.MatchString(s)
 }
 
@@ -60,18 +60,19 @@ type CacheConfig struct {
 }
 
 type MQTTConfig struct {
-	Server    string `yaml:"server"`
-	TopicPath string `yaml:"topic_path"`
-	User      string `yaml:"user"`
-	Password  string `yaml:"password"`
-	QoS       byte   `yaml:"qos"`
+	Server        string `yaml:"server"`
+	TopicPath     string `yaml:"topic_path"`
+	DeviceIDRegex Regexp `yaml:"deviceIDRegex"`
+	User          string `yaml:"user"`
+	Password      string `yaml:"password"`
+	QoS           byte   `yaml:"qos"`
 }
 
 // Metrics Config is a mapping between a metric send on mqtt to a prometheus metric
 type MetricConfig struct {
 	PrometheusName     string                    `yaml:"prom_name"`
 	MQTTName           string                    `yaml:"mqtt_name"`
-	SensorNameFilter   RegexpFilter              `yaml:"sensor_name_filter"`
+	SensorNameFilter   Regexp                    `yaml:"sensor_name_filter"`
 	Help               string                    `yaml:"help"`
 	ValueType          string                    `yaml:"type"`
 	ConstantLabels     map[string]string         `yaml:"const_labels"`

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -25,6 +25,7 @@ type Metric struct {
 	Value       float64
 	ValueType   prometheus.ValueType
 	IngestTime  time.Time
+	Topic       string
 }
 
 type MetricCollection []Metric
@@ -59,6 +60,7 @@ func (c *MemoryCachedCollector) Collect(mc chan<- prometheus.Metric) {
 				metric.ValueType,
 				metric.Value,
 				device,
+				metric.Topic,
 			)
 			if err != nil {
 				panic(err)

--- a/pkg/metrics/ingest.go
+++ b/pkg/metrics/ingest.go
@@ -59,8 +59,9 @@ func (i *Ingest) store(deviceID string, payload []byte) error {
 	for path := range i.metricConfigs {
 		rawValue := parsed.Find(path)
 		parsed.Reset()
-		fmt.Printf("query path: %q data: %v\n", path, rawValue)
-
+		if rawValue == nil {
+			continue
+		}
 		m, err := i.parseMetric(path, deviceID, rawValue)
 		if err != nil {
 			return fmt.Errorf("failed to parse valid metric value: %w", err)

--- a/pkg/metrics/ingest.go
+++ b/pkg/metrics/ingest.go
@@ -128,5 +128,4 @@ func (i *Ingest) SetupSubscriptionHandler(errChan chan<- error) mqtt.MessageHand
 		}
 		i.MessageMetric.WithLabelValues("success", m.Topic()).Inc()
 	}
-
 }


### PR DESCRIPTION
This PR add support for tasmota based devices. I test it with the Gosund SP111 device. 
There are two major changes in this PR:
1. The device ID can be specified by an regex. This regex is applied to the topic path. Thus the device ID can be located everywhere in the topic path.
2. Since tasmota produces nested json object payloads, the json name of the metric will be converted to an [gojsonq path](https://github.com/thedevsaddam/gojsonq/wiki/Queries#findpath). 

This PR should not change any old configuration. Thus it will be downward compatible.

Checklist:

- [x] DeviceID regex
- [x] gojsonq support
- [x] tasmota documentation