### PR TITLE
Changed incorrect port number

### DIFF
--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ../
       dockerfile: Dockerfile
     ports:
-      - 8002:8002
+      - 9641:9641
     volumes:
       - type: bind
         source: ./mqtt2prometheus.yaml

--- a/hack/prometheus.yml
+++ b/hack/prometheus.yml
@@ -27,4 +27,4 @@ scrape_configs:
     scheme: http
     static_configs:
       - targets:
-          - mqtt2prometheus:8002
+          - mqtt2prometheus:9641


### PR DESCRIPTION
As mqtt2promethius is built from source,
it should export 9641:9641 instead of 8002:8002

Fixes issue #17