### PR TITLE
Make GroupValue() more resilient

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,7 +61,7 @@ func (rf *Regexp) GroupValue(s string, groupName string) string {
 	match := rf.r.FindStringSubmatch(s)
 	groupValues := make(map[string]string)
 	for i, name := range rf.r.SubexpNames() {
-		if name != "" {
+		if len(match) > i && name != "" {
 			groupValues[name] = match[i]
 		}
 	}


### PR DESCRIPTION
When sending a topic that doesn't match the configured regex, `mqtt2prometheus` currently just crashes.

This can be reproduced by using this config and then publishing a message to `shellies/test`:

```yaml
mqtt:
  server: tcp://mosquitto:1883
  topic_path: shellies/#
  device_id_regex: "shellies/(?P<deviceid>.*)/sensor"
  metric_per_topic_config:
    metric_name_regex: "shellies/(?P<deviceid>.*)/sensor/(?P<metricname>.*)"
```

This patch ignores topic not parseable by the regex instead and outputs the following error instead:

```
error        cmd/mqtt2prometheus.go:119        Error while processing message
{"error": "could not store metrics '' on topic shellies/test: failed to extract metric values from topic: failed to find valid metric in topic path"}
```