### PR TITLE
Chore/fix cache config

### DIFF
--- a/hack/shelly.yaml
+++ b/hack/shelly.yaml
@@ -5,8 +5,8 @@ mqtt:
   metric_per_topic_config:
     metric_name_regex: "shellies/(?P<deviceid>.*)/sensor/(?P<metricname>.*)"
   qos: 0
-  cache:
-    timeout: 24h
+cache:
+  timeout: 24h
 metrics:
   - prom_name: temperature
     # The name of the metric in a MQTT JSON message

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -9,8 +9,6 @@ import (
 	"time"
 )
 
-const DefaultTimeout = 0
-
 type Collector interface {
 	prometheus.Collector
 	Observe(deviceID string, collection MetricCollection)
@@ -32,7 +30,7 @@ type Metric struct {
 
 type CacheItem struct {
 	DeviceID string
-	Metric Metric
+	Metric   Metric
 }
 
 type MetricCollection []Metric
@@ -52,10 +50,10 @@ func NewCollector(defaultTimeout time.Duration, possibleMetrics []config.MetricC
 func (c *MemoryCachedCollector) Observe(deviceID string, collection MetricCollection) {
 	for _, m := range collection {
 		item := CacheItem{
-			DeviceID: deviceID, 
-			Metric: m,
+			DeviceID: deviceID,
+			Metric:   m,
 		}
-		c.cache.Set(fmt.Sprintf("%s-%s", deviceID, m.Description.String()), item, DefaultTimeout)
+		c.cache.Set(fmt.Sprintf("%s-%s", deviceID, m.Description.String()), item, gocache.DefaultExpiration)
 	}
 }
 


### PR DESCRIPTION
This fixes a typo in the `shelly.yaml` example.  Fixes https://github.com/hikhvar/mqtt2prometheus/issues/52.

Furthermore, I've added a commit to use `const` from upstream for `DefaultExpiration` instead of manually setting it to `0`.

I think this is cleaner, but I can also remove this commit if it's not wanted. See https://github.com/patrickmn/go-cache/blob/46f407853014144407b6c2ec7ccc76bf67958d93/cache.go#L32