### PR TITLE
Use UnmarshalStrict for config file to catch config errors

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -158,7 +158,7 @@ func LoadConfig(configFile string) (Config, error) {
 		return Config{}, err
 	}
 	var cfg Config
-	if err = yaml.Unmarshal(configData, &cfg); err != nil {
+	if err = yaml.UnmarshalStrict(configData, &cfg); err != nil {
 		return cfg, err
 	}
 	if cfg.MQTT == nil {


### PR DESCRIPTION
This uses `StrictUnmarshal()` when parsing the config, which should make it fail when unknown config attributes are used.

This would've helped me spot https://github.com/hikhvar/mqtt2prometheus/issues/52, so I thought it might be worth a consideration.

Here's the error displayed with an invalid YAML:

```
fatal   cmd/mqtt2prometheus.go:72       Could not load config   {"error": "yaml: unmarshal errors:\n  line 8: field cache not found in type config.MQTTConfig"}
```

I've tested this with the other example configs, but not sure if there might be a side effect I'm not catching here. 