### PR TITLE
Use ENTRYPOINT to allow command line argument customization

### DIFF
--- a/release/Dockerfile.scratch
+++ b/release/Dockerfile.scratch
@@ -6,4 +6,4 @@ COPY mqtt2prometheus /mqtt2prometheus
 COPY --from=donor /etc/ssl/certs /etc/ssl/certs
 # Copy Time Zone Data
 COPY --from=donor /usr/share/zoneinfo /usr/share/zoneinfo
-CMD ["/mqtt2prometheus"]
+ENTRYPOINT ["/mqtt2prometheus"]


### PR DESCRIPTION
This brings it in line with the root `Dockerfile` and helps avoid having to repeat the name of the binary when adding command line args.