### PR TITLE
FreeBSD rc script

### DIFF
--- a/freebsd/mqtt2prometheus.rc
+++ b/freebsd/mqtt2prometheus.rc
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# PROVIDE: mqtt2prometheus
+# REQUIRE: NETWORKING DAEMON
+
+. /etc/rc.subr
+
+name=mqtt2prometheus
+rcvar=mqtt2prometheus_enable
+mqtt2prometheus_config="/usr/local/etc/mqtt2prometheus/config.yaml"
+
+command="/usr/local/bin/mqtt2prometheus"
+
+start_cmd="/usr/sbin/daemon -T mqtt2prometheus -u nobody -c $command -config=${mqtt2prometheus_config}"
+
+load_rc_config $name
+run_rc_command "$1"


### PR DESCRIPTION
I’m using the exporter on a FreeBSD box via the existing pkg/port but I noticed there is no rc script included. So I wrote this super basic one that’s been working well for me. 

I might have some time at some point to make it more configurable, but wanted to share the current version in case it’s helpful for someone else. And it can also easily be integrated in the pkg/port. 

Let me know if you’d rather have the more advanced version and I’ll see if I can make some time to update it. 