### PR TITLE
Scaling option for values

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -186,6 +186,8 @@ metrics:
  - prom_name: humidity
   # The name of the metric in a MQTT JSON message
    mqtt_name: humidity
+  # The scale of the metric in a MQTT JSON message (mqtt_value : scale = prom_value : 1)
+   mqtt_value_scale: 100
   # The prometheus help text for this metric
    help: DHT22 humidity reading
   # The prometheus type for this metric. Valid values are: "gauge" and "counter"

--- a/Readme.md
+++ b/Readme.md
@@ -186,7 +186,7 @@ metrics:
  - prom_name: humidity
   # The name of the metric in a MQTT JSON message
    mqtt_name: humidity
-  # The scale of the metric in a MQTT JSON message (mqtt_value : scale = prom_value : 1)
+  # The scale of the metric in a MQTT JSON message (prom_value = mqtt_value * scale)
    mqtt_value_scale: 100
   # The prometheus help text for this metric
    help: DHT22 humidity reading

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,6 +135,7 @@ type MetricConfig struct {
 	ValueType          string                    `yaml:"type"`
 	ConstantLabels     map[string]string         `yaml:"const_labels"`
 	StringValueMapping *StringValueMappingConfig `yaml:"string_value_mapping"`
+	MQTTValueScale     uint32                    `yaml:"mqtt_value_scale"`
 }
 
 // StringValueMappingConfig defines the mapping from string to float

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,7 +135,7 @@ type MetricConfig struct {
 	ValueType          string                    `yaml:"type"`
 	ConstantLabels     map[string]string         `yaml:"const_labels"`
 	StringValueMapping *StringValueMappingConfig `yaml:"string_value_mapping"`
-	MQTTValueScale     uint32                    `yaml:"mqtt_value_scale"`
+	MQTTValueScale     float64                   `yaml:"mqtt_value_scale"`
 }
 
 // StringValueMappingConfig defines the mapping from string to float

--- a/pkg/metrics/parser.go
+++ b/pkg/metrics/parser.go
@@ -96,7 +96,7 @@ func (p *Parser) parseMetric(metricPath string, deviceID string, value interface
 	}
 
 	if cfg.MQTTValueScale != 0 {
-		metricValue = metricValue / float64(cfg.MQTTValueScale)
+		metricValue = metricValue / cfg.MQTTValueScale
 	}
 
 	return Metric{

--- a/pkg/metrics/parser.go
+++ b/pkg/metrics/parser.go
@@ -96,7 +96,7 @@ func (p *Parser) parseMetric(metricPath string, deviceID string, value interface
 	}
 
 	if cfg.MQTTValueScale != 0 {
-		metricValue = metricValue / cfg.MQTTValueScale
+		metricValue = metricValue * cfg.MQTTValueScale
 	}
 
 	return Metric{

--- a/pkg/metrics/parser.go
+++ b/pkg/metrics/parser.go
@@ -94,6 +94,11 @@ func (p *Parser) parseMetric(metricPath string, deviceID string, value interface
 	} else {
 		return Metric{}, fmt.Errorf("got data with unexpectd type: %T ('%s')", value, value)
 	}
+
+	if cfg.MQTTValueScale != 0 {
+		metricValue = metricValue / float64(cfg.MQTTValueScale)
+	}
+
 	return Metric{
 		Description: cfg.PrometheusDescription(),
 		Value:       metricValue,

--- a/pkg/metrics/parser_test.go
+++ b/pkg/metrics/parser_test.go
@@ -59,7 +59,7 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "temperature",
 							ValueType:      "gauge",
-							MQTTValueScale: 100,
+							MQTTValueScale: 0.01,
 						},
 					},
 				},
@@ -129,7 +129,7 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "humidity",
 							ValueType:      "gauge",
-							MQTTValueScale: 100,
+							MQTTValueScale: 0.01,
 						},
 					},
 				},
@@ -155,7 +155,7 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "humidity",
 							ValueType:      "gauge",
-							MQTTValueScale: -0.5,
+							MQTTValueScale: -2,
 						},
 					},
 				},
@@ -206,7 +206,7 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "enabled",
 							ValueType:      "gauge",
-							MQTTValueScale: 2,
+							MQTTValueScale: 0.5,
 						},
 					},
 				},

--- a/pkg/metrics/parser_test.go
+++ b/pkg/metrics/parser_test.go
@@ -1,11 +1,12 @@
 package metrics
 
 import (
-	"github.com/hikhvar/mqtt2prometheus/pkg/config"
-	"github.com/prometheus/client_golang/prometheus"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/hikhvar/mqtt2prometheus/pkg/config"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestParser_parseMetric(t *testing.T) {
@@ -90,6 +91,32 @@ func TestParser_parseMetric(t *testing.T) {
 				Description: prometheus.NewDesc("temperature", "", []string{"sensor", "topic"}, nil),
 				ValueType:   prometheus.GaugeValue,
 				Value:       12.6,
+				IngestTime:  testNow(),
+				Topic:       "",
+			},
+		},
+		{
+			name: "scaled float value",
+			fields: fields{
+				map[string][]config.MetricConfig{
+					"humidity": []config.MetricConfig{
+						{
+							PrometheusName: "humidity",
+							ValueType:      "gauge",
+							MQTTValueScale: 100,
+						},
+					},
+				},
+			},
+			args: args{
+				metricPath: "humidity",
+				deviceID:   "dht22",
+				value:      12.6,
+			},
+			want: Metric{
+				Description: prometheus.NewDesc("humidity", "", []string{"sensor", "topic"}, nil),
+				ValueType:   prometheus.GaugeValue,
+				Value:       0.126,
 				IngestTime:  testNow(),
 				Topic:       "",
 			},

--- a/pkg/metrics/parser_test.go
+++ b/pkg/metrics/parser_test.go
@@ -52,6 +52,32 @@ func TestParser_parseMetric(t *testing.T) {
 			},
 		},
 		{
+			name: "scaled string value",
+			fields: fields{
+				map[string][]config.MetricConfig{
+					"temperature": []config.MetricConfig{
+						{
+							PrometheusName: "temperature",
+							ValueType:      "gauge",
+							MQTTValueScale: 100,
+						},
+					},
+				},
+			},
+			args: args{
+				metricPath: "temperature",
+				deviceID:   "dht22",
+				value:      "12.6",
+			},
+			want: Metric{
+				Description: prometheus.NewDesc("temperature", "", []string{"sensor", "topic"}, nil),
+				ValueType:   prometheus.GaugeValue,
+				Value:       0.126,
+				IngestTime:  testNow(),
+				Topic:       "",
+			},
+		},
+		{
 			name: "string value failure",
 			fields: fields{
 				map[string][]config.MetricConfig{
@@ -122,6 +148,32 @@ func TestParser_parseMetric(t *testing.T) {
 			},
 		},
 		{
+			name: "negative scaled float value",
+			fields: fields{
+				map[string][]config.MetricConfig{
+					"humidity": []config.MetricConfig{
+						{
+							PrometheusName: "humidity",
+							ValueType:      "gauge",
+							MQTTValueScale: -0.5,
+						},
+					},
+				},
+			},
+			args: args{
+				metricPath: "humidity",
+				deviceID:   "dht22",
+				value:      12.6,
+			},
+			want: Metric{
+				Description: prometheus.NewDesc("humidity", "", []string{"sensor", "topic"}, nil),
+				ValueType:   prometheus.GaugeValue,
+				Value:       -25.2,
+				IngestTime:  testNow(),
+				Topic:       "",
+			},
+		},
+		{
 			name: "bool value true",
 			fields: fields{
 				map[string][]config.MetricConfig{
@@ -142,6 +194,32 @@ func TestParser_parseMetric(t *testing.T) {
 				Description: prometheus.NewDesc("enabled", "", []string{"sensor", "topic"}, nil),
 				ValueType:   prometheus.GaugeValue,
 				Value:       1,
+				IngestTime:  testNow(),
+				Topic:       "",
+			},
+		},
+		{
+			name: "scaled bool value",
+			fields: fields{
+				map[string][]config.MetricConfig{
+					"enabled": []config.MetricConfig{
+						{
+							PrometheusName: "enabled",
+							ValueType:      "gauge",
+							MQTTValueScale: 2,
+						},
+					},
+				},
+			},
+			args: args{
+				metricPath: "enabled",
+				deviceID:   "dht22",
+				value:      true,
+			},
+			want: Metric{
+				Description: prometheus.NewDesc("enabled", "", []string{"sensor", "topic"}, nil),
+				ValueType:   prometheus.GaugeValue,
+				Value:       0.5,
 				IngestTime:  testNow(),
 				Topic:       "",
 			},


### PR DESCRIPTION
optional `mqtt_value_scale` defines a scale for conversion; example use case: convert percentage into 0.0-1.0 value range