### PR TITLE
Option to omit timestamp

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -216,6 +216,8 @@ metrics:
    help: Light state
   # The prometheus type for this metric. Valid values are: "gauge" and "counter"
    type: gauge
+  # according to prometheus exposition format timestamp is not mandatory, we can omit it if the reporting from the sensor is sporadic
+   omit_timestamp: true
   # A map of string to string for constant labels. This labels will be attached to every prometheus metric
    const_labels:
     sensor_type: ikea

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,6 +133,7 @@ type MetricConfig struct {
 	SensorNameFilter   Regexp                    `yaml:"sensor_name_filter"`
 	Help               string                    `yaml:"help"`
 	ValueType          string                    `yaml:"type"`
+	OmitTimestamp      bool                      `yaml:"omit_timestamp"`
 	ConstantLabels     map[string]string         `yaml:"const_labels"`
 	StringValueMapping *StringValueMappingConfig `yaml:"string_value_mapping"`
 	MQTTValueScale     float64                   `yaml:"mqtt_value_scale"`

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -2,11 +2,12 @@ package metrics
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/hikhvar/mqtt2prometheus/pkg/config"
 	gocache "github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-	"time"
 )
 
 type Collector interface {
@@ -77,7 +78,12 @@ func (c *MemoryCachedCollector) Collect(mc chan<- prometheus.Metric) {
 			device,
 			metric.Topic,
 		)
-		mc <- prometheus.NewMetricWithTimestamp(metric.IngestTime, m)
+
+		if metric.IngestTime.IsZero() {
+			mc <- m
+		} else {
+			mc <- prometheus.NewMetricWithTimestamp(metric.IngestTime, m)
+		}
 
 	}
 }

--- a/pkg/metrics/parser.go
+++ b/pkg/metrics/parser.go
@@ -99,10 +99,15 @@ func (p *Parser) parseMetric(metricPath string, deviceID string, value interface
 		metricValue = metricValue * cfg.MQTTValueScale
 	}
 
+	var ingestTime time.Time
+	if !cfg.OmitTimestamp {
+		ingestTime = now()
+	}
+
 	return Metric{
 		Description: cfg.PrometheusDescription(),
 		Value:       metricValue,
 		ValueType:   cfg.PrometheusValueType(),
-		IngestTime:  now(),
+		IngestTime:  ingestTime,
 	}, nil
 }

--- a/pkg/metrics/parser_test.go
+++ b/pkg/metrics/parser_test.go
@@ -27,6 +27,32 @@ func TestParser_parseMetric(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "value without timestamp",
+			fields: fields{
+				map[string][]config.MetricConfig{
+					"temperature": []config.MetricConfig{
+						{
+							PrometheusName: "temperature",
+							ValueType:      "gauge",
+							OmitTimestamp:  true,
+						},
+					},
+				},
+			},
+			args: args{
+				metricPath: "temperature",
+				deviceID:   "dht22",
+				value:      12.6,
+			},
+			want: Metric{
+				Description: prometheus.NewDesc("temperature", "", []string{"sensor", "topic"}, nil),
+				ValueType:   prometheus.GaugeValue,
+				Value:       12.6,
+				IngestTime:  time.Time{},
+				Topic:       "",
+			},
+		},
+		{
 			name: "string value",
 			fields: fields{
 				map[string][]config.MetricConfig{


### PR DESCRIPTION
In prometheus exposition format timestamps are not mandatory; here's my current setup:

- ESP32 is emitting external temp and hum to MQTT and then going into deep sleep for 15 minutes
- Omitting the timestamp let the scraping "to emit" a value on each scrape
 
I opted for `0` time value instead of playing with pointers and `nil`