### PR TITLE
Allow overriding the device id regex per metric

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -126,7 +126,7 @@ type MetricPerTopicConfig struct {
 	MetricNameRegex *Regexp `yaml:"metric_name_regex"` // Default
 }
 
-// Metrics Config is a mapping between a metric send on mqtt to a prometheus metric
+// Metrics Config is a mapping between a metric sent on mqtt and a prometheus metric
 type MetricConfig struct {
 	PrometheusName     string                    `yaml:"prom_name"`
 	MQTTName           string                    `yaml:"mqtt_name"`
@@ -137,6 +137,7 @@ type MetricConfig struct {
 	ConstantLabels     map[string]string         `yaml:"const_labels"`
 	StringValueMapping *StringValueMappingConfig `yaml:"string_value_mapping"`
 	MQTTValueScale     float64                   `yaml:"mqtt_value_scale"`
+	DeviceIDRegex      *Regexp                   `yaml:"device_id_regex"`
 }
 
 // StringValueMappingConfig defines the mapping from string to float
@@ -184,18 +185,23 @@ func LoadConfig(configFile string) (Config, error) {
 	if cfg.MQTT.DeviceIDRegex == nil {
 		cfg.MQTT.DeviceIDRegex = MQTTConfigDefaults.DeviceIDRegex
 	}
-	var validRegex bool
-	for _, name := range cfg.MQTT.DeviceIDRegex.RegEx().SubexpNames() {
-		if name == DeviceIDRegexGroup {
-			validRegex = true
-		}
-	}
-	if !validRegex {
+	if !validDeviceIDRegexp(cfg.MQTT.DeviceIDRegex, DeviceIDRegexGroup) {
 		return Config{}, fmt.Errorf("device id regex %q does not contain required regex group %q", cfg.MQTT.DeviceIDRegex.pattern, DeviceIDRegexGroup)
 	}
 
 	if cfg.MQTT.ObjectPerTopicConfig != nil && cfg.MQTT.MetricPerTopicConfig != nil {
 		return Config{}, fmt.Errorf("only one of object_per_topic_config and metric_per_topic_config can be specified")
+	}
+
+	// Check DeviceIDRegex on each MetricConfig and populate with the default if it's not set
+	for idx, config := range cfg.Metrics {
+		if config.DeviceIDRegex != nil {
+			if !validDeviceIDRegexp(config.DeviceIDRegex, DeviceIDRegexGroup) {
+				return Config{}, fmt.Errorf("device id regex %q does not contain required regex group %q", config.DeviceIDRegex.pattern, DeviceIDRegexGroup)
+			}
+		} else {
+			cfg.Metrics[idx].DeviceIDRegex = cfg.MQTT.DeviceIDRegex
+		}
 	}
 
 	if cfg.MQTT.ObjectPerTopicConfig == nil && cfg.MQTT.MetricPerTopicConfig == nil {
@@ -205,16 +211,19 @@ func LoadConfig(configFile string) (Config, error) {
 	}
 
 	if cfg.MQTT.MetricPerTopicConfig != nil {
-		validRegex = false
-		for _, name := range cfg.MQTT.MetricPerTopicConfig.MetricNameRegex.RegEx().SubexpNames() {
-			if name == MetricNameRegexGroup {
-				validRegex = true
-			}
-		}
-		if !validRegex {
+		if !validDeviceIDRegexp(cfg.MQTT.MetricPerTopicConfig.MetricNameRegex, MetricNameRegexGroup) {
 			return Config{}, fmt.Errorf("metric name regex %q does not contain required regex group %q", cfg.MQTT.DeviceIDRegex.pattern, MetricNameRegexGroup)
 		}
 	}
 
 	return cfg, nil
+}
+
+func validDeviceIDRegexp(regexp *Regexp, requiredGroup string) bool {
+	for _, name := range regexp.RegEx().SubexpNames() {
+		if name == requiredGroup {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -12,7 +12,7 @@ import (
 
 type Collector interface {
 	prometheus.Collector
-	Observe(deviceID string, collection MetricCollection)
+	Observe(collection MetricCollection)
 }
 
 type MemoryCachedCollector struct {
@@ -27,6 +27,7 @@ type Metric struct {
 	ValueType   prometheus.ValueType
 	IngestTime  time.Time
 	Topic       string
+	DeviceID    string
 }
 
 type CacheItem struct {
@@ -48,13 +49,14 @@ func NewCollector(defaultTimeout time.Duration, possibleMetrics []config.MetricC
 	}
 }
 
-func (c *MemoryCachedCollector) Observe(deviceID string, collection MetricCollection) {
+func (c *MemoryCachedCollector) Observe(collection MetricCollection) {
 	for _, m := range collection {
+		// TODO: Now that DeviceID is part of Metric, perhaps we don't need the CacheItem any more?
 		item := CacheItem{
-			DeviceID: deviceID,
+			DeviceID: m.DeviceID,
 			Metric:   m,
 		}
-		c.cache.Set(fmt.Sprintf("%s-%s", deviceID, m.Description.String()), item, gocache.DefaultExpiration)
+		c.cache.Set(fmt.Sprintf("%s-%s", m.DeviceID, m.Description.String()), item, gocache.DefaultExpiration)
 	}
 }
 

--- a/pkg/metrics/parser.go
+++ b/pkg/metrics/parser.go
@@ -34,15 +34,17 @@ func (p *Parser) config() map[string][]config.MetricConfig {
 	return p.metricConfigs
 }
 
-// validMetric returns config matching the metric and deviceID
-// Second return value indicates if config was found.
-func (p *Parser) findMetricConfig(metric string, deviceID string) (config.MetricConfig, bool) {
+// validMetric returns config matching the metric and the deviceID extracted from the topic
+// Third return value indicates if config was found.
+func (p *Parser) findMetricConfig(metric string, topic string) (config.MetricConfig, string, bool) {
 	for _, c := range p.metricConfigs[metric] {
-		if c.SensorNameFilter.Match(deviceID) {
-			return c, true
+		// use DeviceIDRegex to extract the device ID from the given mqtt topic path
+		deviceId := c.DeviceIDRegex.GroupValue(topic, config.DeviceIDRegexGroup)
+		if c.SensorNameFilter.Match(deviceId) {
+			return c, deviceId, true
 		}
 	}
-	return config.MetricConfig{}, false
+	return config.MetricConfig{}, "", false
 }
 
 // parseMetric parses the given value according to the given deviceID and metricPath. The config allows to

--- a/pkg/metrics/parser_test.go
+++ b/pkg/metrics/parser_test.go
@@ -16,7 +16,7 @@ func TestParser_parseMetric(t *testing.T) {
 	}
 	type args struct {
 		metricPath string
-		deviceID   string
+		topic      string
 		value      interface{}
 	}
 	tests := []struct {
@@ -35,13 +35,14 @@ func TestParser_parseMetric(t *testing.T) {
 							PrometheusName: "temperature",
 							ValueType:      "gauge",
 							OmitTimestamp:  true,
+							DeviceIDRegex:  config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "temperature",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      12.6,
 			},
 			want: Metric{
@@ -60,13 +61,14 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "temperature",
 							ValueType:      "gauge",
+							DeviceIDRegex:  config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "temperature",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      "12.6",
 			},
 			want: Metric{
@@ -86,13 +88,14 @@ func TestParser_parseMetric(t *testing.T) {
 							PrometheusName: "temperature",
 							ValueType:      "gauge",
 							MQTTValueScale: 0.01,
+							DeviceIDRegex:  config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "temperature",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      "12.6",
 			},
 			want: Metric{
@@ -111,13 +114,14 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "temperature",
 							ValueType:      "gauge",
+							DeviceIDRegex:  config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "temperature",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      "12.6.5",
 			},
 			wantErr: true,
@@ -130,13 +134,14 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "temperature",
 							ValueType:      "gauge",
+							DeviceIDRegex:  config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "temperature",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      12.6,
 			},
 			want: Metric{
@@ -156,13 +161,14 @@ func TestParser_parseMetric(t *testing.T) {
 							PrometheusName: "humidity",
 							ValueType:      "gauge",
 							MQTTValueScale: 0.01,
+							DeviceIDRegex:  config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "humidity",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      12.6,
 			},
 			want: Metric{
@@ -182,13 +188,14 @@ func TestParser_parseMetric(t *testing.T) {
 							PrometheusName: "humidity",
 							ValueType:      "gauge",
 							MQTTValueScale: -2,
+							DeviceIDRegex:  config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "humidity",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      12.6,
 			},
 			want: Metric{
@@ -207,13 +214,14 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "enabled",
 							ValueType:      "gauge",
+							DeviceIDRegex:  config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "enabled",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      true,
 			},
 			want: Metric{
@@ -233,13 +241,14 @@ func TestParser_parseMetric(t *testing.T) {
 							PrometheusName: "enabled",
 							ValueType:      "gauge",
 							MQTTValueScale: 0.5,
+							DeviceIDRegex:  config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "enabled",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      true,
 			},
 			want: Metric{
@@ -258,13 +267,14 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "enabled",
 							ValueType:      "gauge",
+							DeviceIDRegex:  config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "enabled",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      false,
 			},
 			want: Metric{
@@ -289,13 +299,14 @@ func TestParser_parseMetric(t *testing.T) {
 									"bar": 2,
 								},
 							},
+							DeviceIDRegex: config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "enabled",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      "foo",
 			},
 			want: Metric{
@@ -321,13 +332,14 @@ func TestParser_parseMetric(t *testing.T) {
 									"bar": 2,
 								},
 							},
+							DeviceIDRegex: config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "enabled",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      "asd",
 			},
 			want: Metric{
@@ -352,13 +364,14 @@ func TestParser_parseMetric(t *testing.T) {
 									"bar": 2,
 								},
 							},
+							DeviceIDRegex: config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "enabled",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      "asd",
 			},
 			wantErr: true,
@@ -378,13 +391,14 @@ func TestParser_parseMetric(t *testing.T) {
 									"bar": 2,
 								},
 							},
+							DeviceIDRegex: config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "enabled1",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      "asd",
 			},
 			wantErr: true,
@@ -404,13 +418,14 @@ func TestParser_parseMetric(t *testing.T) {
 									"bar": 2,
 								},
 							},
+							DeviceIDRegex: config.MQTTConfigDefaults.DeviceIDRegex,
 						},
 					},
 				},
 			},
 			args: args{
 				metricPath: "enabled",
-				deviceID:   "dht22",
+				topic:      "devices/home/dht22",
 				value:      []int{3},
 			},
 			wantErr: true,
@@ -423,7 +438,7 @@ func TestParser_parseMetric(t *testing.T) {
 			}
 
 			// Find a valid metrics config
-			config, found := p.findMetricConfig(tt.args.metricPath, tt.args.deviceID)
+			config, _, found := p.findMetricConfig(tt.args.metricPath, tt.args.topic)
 			if !found {
 				if !tt.wantErr {
 					t.Errorf("MetricConfig not found")


### PR DESCRIPTION
This allows the regex used to extract the device id to be overriden per metric. This required a little reorganizing of where the device id is parsed from the topic (and therefore how it's passed between functions). The default parsing remains the same.

This is useful (in my installation) with the availability topic created by Zigbee2MQTT. It creates topics like, `zigbee2mqtt/thermostat/availability` for availability. The main topic, `zigbee2mqtt/thermostat`, has the main set of metrics (and correctly parses using the default device id regex) but then `zigbee2mqtt/thermostat/availability` has `{"state":"online"}`. With this change, I can add a config that looks like this,
```
 - prom_name: availability
   mqtt_name: state
   help: Device availability (from Zigbee2MQTT)
   type: gauge
   device_id_regex: "zigbee2mqtt/(?P<deviceid>.*)/availability"
   string_value_mapping:
    # A map of string to metric value.
    map:
     online: 1
     offline: 0
```
and then get a bunch of metrics that look like this,
```
availability{sensor="living_room",topic="zigbee2mqtt/living_room/availability"} 1 1672873723990
availability{sensor="bedroom",topic="zigbee2mqtt/bedroom/availability"} 1 1672873723964
availability{sensor="thermostat",topic="zigbee2mqtt/thermostat/availability"} 1 1672873723964
```