### PR TITLE
add support for reading mqtt password from file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -129,6 +129,8 @@ Usage of ./mqtt2prometheus:
         show the builds version, date and commit
   -web-config-file string
         [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication for metric scraping.
+  -use-secret bool (default: false)
+        treat MQTT2PROM_MQTT_PASSWORD environment variable as a secret file path e.g. /var/run/secrets/mqtt-credential 
 ```
 The logging is implemented via [zap](https://github.com/uber-go/zap). The logs are printed to `stderr` and valid log levels are
 those supported by zap.  
@@ -266,6 +268,26 @@ Then load that file into the environment before starting the container:
   -p 9641:9641 \
   ghcr.io/hikhvar/mqtt2prometheus:latest
 ```
+
+#### Example use with Docker secret (in swarm)
+
+Create a docker secret to store the password(`mqtt-credential` in the example below), and pass the optional `use-secret` command line argument.
+```docker
+  mqtt_exporter_tasmota:
+    image: ghcr.io/hikhvar/mqtt2prometheus:latest 
+    secrets:
+      - mqtt-credential 
+    environment:
+      - MQTT2PROM_MQTT_USER=mqtt
+      - MQTT2PROM_MQTT_PASSWORD=/var/run/secrets/mqtt-credential
+    entrypoint:
+      - /mqtt2prometheus
+      - -log-level=debug
+      - -use-secret=true
+    volumes:
+        - config-tasmota.yml:/config.yaml:ro
+```
+
 
 
 ## Frequently Asked Questions

--- a/Readme.md
+++ b/Readme.md
@@ -129,8 +129,8 @@ Usage of ./mqtt2prometheus:
         show the builds version, date and commit
   -web-config-file string
         [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication for metric scraping.
-  -use-secret bool (default: false)
-        treat MQTT2PROM_MQTT_PASSWORD environment variable as a secret file path e.g. /var/run/secrets/mqtt-credential 
+  -treat-mqtt-password-as-file-name bool (default: false)
+        treat MQTT2PROM_MQTT_PASSWORD environment variable as a secret file path e.g. /var/run/secrets/mqtt-credential. Usefule when docker secret or external credential management agents handle the secret file. 
 ```
 The logging is implemented via [zap](https://github.com/uber-go/zap). The logs are printed to `stderr` and valid log levels are
 those supported by zap.  
@@ -271,7 +271,7 @@ Then load that file into the environment before starting the container:
 
 #### Example use with Docker secret (in swarm)
 
-Create a docker secret to store the password(`mqtt-credential` in the example below), and pass the optional `use-secret` command line argument.
+Create a docker secret to store the password(`mqtt-credential` in the example below), and pass the optional `treat-mqtt-password-as-file-name` command line argument.
 ```docker
   mqtt_exporter_tasmota:
     image: ghcr.io/hikhvar/mqtt2prometheus:latest 
@@ -283,7 +283,7 @@ Create a docker secret to store the password(`mqtt-credential` in the example be
     entrypoint:
       - /mqtt2prometheus
       - -log-level=debug
-      - -use-secret=true
+      - -treat-mqtt-password-as-file-name=true
     volumes:
         - config-tasmota.yml:/config.yaml:ro
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -130,7 +130,7 @@ Usage of ./mqtt2prometheus:
   -web-config-file string
         [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication for metric scraping.
   -treat-mqtt-password-as-file-name bool (default: false)
-        treat MQTT2PROM_MQTT_PASSWORD environment variable as a secret file path e.g. /var/run/secrets/mqtt-credential. Usefule when docker secret or external credential management agents handle the secret file. 
+        treat MQTT2PROM_MQTT_PASSWORD environment variable as a secret file path e.g. /var/run/secrets/mqtt-credential. Useful when docker secret or external credential management agents handle the secret file. 
 ```
 The logging is implemented via [zap](https://github.com/uber-go/zap). The logs are printed to `stderr` and valid log levels are
 those supported by zap.  

--- a/cmd/mqtt2prometheus.go
+++ b/cmd/mqtt2prometheus.go
@@ -65,7 +65,7 @@ var (
 		"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication for metric scraping.",
 	)
 	usePasswordFromFile = flag.Bool(
-		"use-secret",
+		"treat-mqtt-password-as-file-name",
 		false,
 		"treat MQTT2PROM_MQTT_PASSWORD as a secret file path e.g. /var/run/secrets/mqtt-credential",
 	)
@@ -92,7 +92,7 @@ func main() {
 
 	mqtt_password := os.Getenv("MQTT2PROM_MQTT_PASSWORD")
 	if *usePasswordFromFile {
-		if mqtt_password != "" {
+		if mqtt_password == "" {
 			logger.Fatal("MQTT2PROM_MQTT_PASSWORD is required")
 		}
 		secret, err := ioutil.ReadFile(mqtt_password)

--- a/cmd/mqtt2prometheus.go
+++ b/cmd/mqtt2prometheus.go
@@ -64,6 +64,11 @@ var (
 		"",
 		"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication for metric scraping.",
 	)
+	usePasswordFromFile = flag.Bool(
+		"use-secret",
+		false,
+		"treat MQTT2PROM_MQTT_PASSWORD as a secret file path e.g. /var/run/secrets/mqtt-credential",
+	)
 )
 
 func main() {
@@ -81,13 +86,24 @@ func main() {
 	}
 
 	mqtt_user := os.Getenv("MQTT2PROM_MQTT_USER")
-	mqtt_password := os.Getenv("MQTT2PROM_MQTT_PASSWORD")
-
 	if mqtt_user != "" {
 		cfg.MQTT.User = mqtt_user
 	}
-	if mqtt_password != "" {
-		cfg.MQTT.Password = mqtt_password
+
+	mqtt_password := os.Getenv("MQTT2PROM_MQTT_PASSWORD")
+	if *usePasswordFromFile {
+		if mqtt_password != "" {
+			logger.Fatal("MQTT2PROM_MQTT_PASSWORD is required")
+		}
+		secret, err := ioutil.ReadFile(mqtt_password)
+		if err != nil {
+			logger.Fatal("unable to read mqtt password from secret file", zap.Error(err))
+		}
+		cfg.MQTT.Password = string(secret)
+	} else {
+		if mqtt_password != "" {
+			cfg.MQTT.Password = mqtt_password
+		}
 	}
 
 	mqttClientOptions := mqtt.NewClientOptions()


### PR DESCRIPTION
This PR adds support for reading the password from a secret file. Usually if the base image has a shell, we can modify the entry point to a shell and create the environment variable, (e.g. `/bin/sh -c export MQTT2PROM_MQTT_PASSWORD=$$(cat /var/run/secrets/mqtt-credential); /mqtt2prometheus`) but with a distroless base image we don't have that option. 
Fixes #117 