### PR TITLE
Improve systemd unit file security and fix debian packaging

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,8 +75,7 @@ nfpms:
       - apk
     conflicts:
       - prometheus-mqtt-exporter
-    scripts:
-      postinstall: systemd/postinstall.sh
+    bindir: /usr/bin
     contents:
       # Simple config file
       - src: config.yaml.dist
@@ -84,6 +83,9 @@ nfpms:
         type: config
       - src: ./systemd/mqtt2prometheus.service
         dst: /etc/systemd/system/mqtt2prometheus.service
+        type: config
+      - src: ./systemd/mqtt2prometheus
+        dst: /etc/default/mqtt2prometheus
         type: config
 
 

--- a/systemd/mqtt2prometheus
+++ b/systemd/mqtt2prometheus
@@ -1,0 +1,4 @@
+# Command line options for mqtt2prometheus.service
+# See also /etc/mqtt2prometheus/config.yaml
+
+ARGS="-config /etc/mqtt2prometheus/config.yaml"

--- a/systemd/mqtt2prometheus.service
+++ b/systemd/mqtt2prometheus.service
@@ -1,15 +1,47 @@
 [Unit]
 Description=Simple translator from mqtt messages to prometheus. Analog to pushgateway
 Documentation=https://github.com/hikhvar/mqtt2prometheus
+After=network.target
 Before=prometheus.service
 
 [Service]
 Restart=always
-User=mqtt2prometheus
-EnvironmentFile=/etc/default/prometheus-mqtt-exporter
-ExecStart=/opt/mqtt2prometheus/mqtt2prometheus -config /etc/mqtt2prometheus/config.yaml $ARGS
+EnvironmentFile=/etc/default/mqtt2prometheus
+ExecStart=/usr/bin/mqtt2prometheus $ARGS
 TimeoutStopSec=20s
 
+# Extra security hardening options
+# See systemd.exec(5) for more information regarding these options.
+
+# Empty because mqtt2prometheus does not require any special capability. See capabilities(7) for more information.
+CapabilityBoundingSet=
+DynamicUser=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+PrivateUsers=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service
+UMask=077
+
+# See systemd.resource-control(5) for more information
+#IPAddressAllow=127.0.0.0/8
+#IPAddressDeny=any # the allow-list is evaluated before the deny list. Since the default is to allow, we need to deny everything.
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/postinstall.sh
+++ b/systemd/postinstall.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-user=mqtt2prometheus
-if ! getent passwd "${user}" > /dev/null; then
-    useradd --system --home-dir /var/lib/${user} --no-create-home || true
-fi


### PR DESCRIPTION
I tried installing mqtt2prometheus using the provided debian package, but I had a few issues with it:

- The environment file that is used in the systemd service, is not actually provided in the package. I fixed this by adding a default environment file and adjusting the goreleaser config accordingly
- I had some issues because the `mqtt2prometheus` user was not created correctly. However, it is also not really required to create a separate user for a service like this, so I added the `DynamicUser=true` option to the systemd service file. While at this, I also added some other security hardening options. The service runs fine with these options on my install (Ubuntu Server 22.04) and as far as I can tell it should run fine like this, but as always with security options, it can cause problems down the line.

One last issue I came across while creating this PR, is that in v0.16, the binary is installed into `/usr/local/bin`, but in v0.17 it is installed into `/usr/bin`. I made the latter option now explicit in the goreleaser configuration, but could not actually find out what caused this change (maybe a change in goreleaser version changed a default somewhere?)