### PR TITLE
Use separate prometheus registry

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,7 @@ This exporter makes some assumptions about the MQTT topics. This exporter assume
 client publish the metrics into a dedicated topic. The regular expression in the configuration field `mqtt.device_id_regex`
 defines how to extract the device ID from the MQTT topic. This allows an arbitrary place of the device ID in the mqtt topic.
 For example the [tasmota](https://github.com/arendst/Tasmota) firmware pushes the telemetry data to the topics `tele/<deviceid>/SENSOR`.
+The regex supports an list of multiple pattern to probe the topic for.
 
 Let us assume the default configuration from [configuration file](#config-file). A sensor publishes the following message
 ```json
@@ -34,6 +35,7 @@ humidity{sensor="livingroom",topic="devices/home/livingroom"} 51.6
 
 The label `sensor` is extracted with the default `device_id_regex` `(.*/)?(?P<deviceid>.*)` from the MQTT topic `devices/home/livingroom`.
 The `device_id_regex` is able to extract exactly one label from the topic path. It extracts only the `deviceid` regex capture group into the `sensor` prometheus label.
+But multiple regex patterns are supported ant the topic will be probed for.
 To extract more labels from the topic path, have a look at [this FAQ answer](#extract-more-labels-from-the-topic-path).
 
 The topic path can contain multiple wildcards. MQTT has two wildcards: 
@@ -158,7 +160,8 @@ mqtt:
  # that the last "element" of the topic_path is the device id.
  # The regular expression must contain a named capture group with the name deviceid
  # For example the expression for tasamota based sensors is "tele/(?P<deviceid>.*)/.*"
- device_id_regex: "(.*/)?(?P<deviceid>.*)"
+ device_id_regex:
+  - "(.*/)?(?P<deviceid>.*)"
  # The MQTT QoS level
  qos: 0
  # NOTE: Only one of metric_per_topic_config or object_per_topic_config should be specified in the configuration

--- a/cmd/mqtt2prometheus.go
+++ b/cmd/mqtt2prometheus.go
@@ -151,9 +151,11 @@ func main() {
 		time.Sleep(10 * time.Second)
 	}
 
-	prometheus.MustRegister(ingest.Collector())
-	prometheus.MustRegister(collector)
-	http.Handle("/metrics", promhttp.Handler())
+        r := prometheus.NewRegistry()
+        r.MustRegister(ingest.Collector())
+        r.MustRegister(collector)
+        handler := promhttp.HandlerFor(r, promhttp.HandlerOpts{})
+        http.Handle("/metrics", handler)
 	s := &http.Server{
 		Addr:    getListenAddress(),
 		Handler: http.DefaultServeMux,

--- a/cmd/mqtt2prometheus.go
+++ b/cmd/mqtt2prometheus.go
@@ -38,16 +38,6 @@ var (
 		"config.yaml",
 		"config file",
 	)
-	portFlag = flag.String(
-		"listen-port",
-		"9641",
-		"HTTP port used to expose metrics",
-	)
-	addressFlag = flag.String(
-		"listen-address",
-		"0.0.0.0",
-		"listen address for HTTP server used to expose metrics",
-	)
 	versionFlag = flag.Bool(
 		"version",
 		false,
@@ -151,13 +141,13 @@ func main() {
 		time.Sleep(10 * time.Second)
 	}
 
-        r := prometheus.NewRegistry()
-        r.MustRegister(ingest.Collector())
-        r.MustRegister(collector)
-        handler := promhttp.HandlerFor(r, promhttp.HandlerOpts{})
-        http.Handle("/metrics", handler)
+	r := prometheus.NewRegistry()
+	r.MustRegister(ingest.Collector())
+	r.MustRegister(collector)
+	handler := promhttp.HandlerFor(r, promhttp.HandlerOpts{})
+	http.Handle("/metrics", handler)
 	s := &http.Server{
-		Addr:    getListenAddress(),
+		Addr:    getListenAddress(cfg),
 		Handler: http.DefaultServeMux,
 	}
 	go func() {
@@ -178,8 +168,8 @@ func main() {
 	}
 }
 
-func getListenAddress() string {
-	return fmt.Sprintf("%s:%s", *addressFlag, *portFlag)
+func getListenAddress(cfg config.Config) string {
+	return fmt.Sprintf("%s:%s", cfg.Interface, cfg.Port)
 }
 
 func mustShowVersion() {

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -16,7 +16,8 @@ mqtt:
   # that the last "element" of the topic_path is the device id.
   # The regular expression must contain a named capture group with the name deviceid
   # For example the expression for tasamota based sensors is "tele/(?P<deviceid>.*)/.*"
-  # device_id_regex: "(.*/)?(?P<deviceid>.*)"
+  # device_id_regex:
+  #  - "(.*/)?(?P<deviceid>.*)"
   # The MQTT QoS level
   qos: 0
 cache:

--- a/examples/gosund_sp111.yaml
+++ b/examples/gosund_sp111.yaml
@@ -11,7 +11,8 @@ mqtt:
   # that the last "element" of the topic_path is the device id.
   # The regular expression must contain a named capture group with the name deviceid
   # For example the expression for tasamota based sensors is "tele/(?P<deviceid>.*)/.*"
-  device_id_regex: "tele/(?P<deviceid>.*)/SENSOR"
+  device_id_regex:
+    - "tele/(?P<deviceid>.*)/SENSOR"
   # The MQTT QoS level
   qos: 0
 cache:

--- a/examples/shelly_3em.yaml
+++ b/examples/shelly_3em.yaml
@@ -32,7 +32,8 @@ mqtt:
   topic_path: shellies/shellyem3-123456789/emeter/+/+
 
   # Use the phase number as device_id in order to see all three phases in /metrics
-  device_id_regex: "shellies/(.*)/emeter/(?P<deviceid>.*)/.*"
+  device_id_regex:
+    - "shellies/(.*)/emeter/(?P<deviceid>.*)/.*"
 
   # Metrics are being published on a per-topic basis.
   metric_per_topic_config:

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,4 @@ require (
 	github.com/prometheus/exporter-toolkit v0.7.3
 	github.com/thedevsaddam/gojsonq/v2 v2.5.2
 	go.uber.org/zap v1.16.0
-	gopkg.in/yaml.v2 v2.4.0
 )

--- a/hack/dht22.yaml
+++ b/hack/dht22.yaml
@@ -1,8 +1,8 @@
-# Settings for the MQTT Client. Currently only these three are supported
 # listen address for HTTP server used to expose metrics
 interface: 0.0.0.0
 # HTTP port used to expose metrics
 port: 9641
+# Settings for the MQTT Client. Currently only these three are supported
 mqtt:
   # The MQTT broker to connect to
   server: tcp://mosquitto:1883

--- a/hack/dht22.yaml
+++ b/hack/dht22.yaml
@@ -1,4 +1,8 @@
 # Settings for the MQTT Client. Currently only these three are supported
+# listen address for HTTP server used to expose metrics
+interface: 0.0.0.0
+# HTTP port used to expose metrics
+port: 9641
 mqtt:
   # The MQTT broker to connect to
   server: tcp://mosquitto:1883

--- a/hack/shelly.yaml
+++ b/hack/shelly.yaml
@@ -1,7 +1,8 @@
 mqtt:
   server: tcp://mosquitto:1883
   topic_path: shellies/+/sensor/+
-  device_id_regex: "shellies/(?P<deviceid>.*)/sensor"
+  device_id_regex:
+    - "shellies/(?P<deviceid>.*)/sensor"
   metric_per_topic_config:
     metric_name_regex: "shellies/(?P<deviceid>.*)/sensor/(?P<metricname>.*)"
   qos: 0

--- a/hack/smarthome.yaml
+++ b/hack/smarthome.yaml
@@ -1,0 +1,90 @@
+qtt:
+  server: tcp://127.0.0.1:1883
+  user: someuser
+  password: somepassword
+  topic_path:
+    - zigbee2mqtt/0x00124b22292b470a
+    - Viessmann/status/json
+    - tele/tasmota_6DD88C/SENSOR
+  device_id_regex:
+    - zigbee2mqtt/(?P<deviceid>(.+))
+    - (?P<deviceid>(Viessmann))/status/json
+    - tele/(?P<deviceid>(tasmota_.+))/SENSOR
+metrics:
+# for a zigbee briged sonoff temperature sensor
+  - prom_name: Temperature
+    mqtt_name: temperature
+    help: current power
+    type: gauge
+  - prom_name: Humidity
+    mqtt_name: humidity
+    help: total used
+    type: gauge
+  - prom_name: Battery
+    mqtt_name: battery
+    help: total used
+    type: gauge
+
+# for a tasmota esp driven main power meter
+  - prom_name: Power_curr
+    mqtt_name: .Power_curr
+    help: current power
+    type: gauge
+  - prom_name: Total_in
+    mqtt_name: .Total_in
+    help: total used
+    type: counter
+
+# for a viessmann kw100 heating system
+  - prom_name: getTempA
+    mqtt_name: getTempA
+    help: current power
+    type: gauge
+  - prom_name: getTempWWist
+    mqtt_name: getTempWWist
+    help: total used
+    type: gauge
+  - prom_name: getTempKist
+    mqtt_name: getTempKist
+    help: current power
+    type: gauge
+  - prom_name: getTempKsoll
+    mqtt_name: getTempKsoll
+    help: current power
+    type: gauge
+  - prom_name: getBrennerStatus
+    mqtt_name: getBrennerStatus
+    help: current power
+    type: gauge
+  - prom_name: getBrennerStarts
+    mqtt_name: getBrennerStarts
+    help: current power
+    type: counter
+  - prom_name: getBrennerStunden1
+    mqtt_name: getBrennerStunden1
+    help: current power
+    type: counter
+  - prom_name: getBrennerStunden2
+    mqtt_name: getBrennerStunden2
+    help: current power
+    type: counter
+  - prom_name: getPumpeStatusM1
+    mqtt_name: getPumpeStatusM1
+    help: current power
+    type: gauge
+  - prom_name: getStatusStoerung
+    mqtt_name: getStatusStoerung
+    help: current power
+    type: gauge
+  - prom_name: getBrennerStoerung
+    mqtt_name: getBrennerStoerung
+    help: current power
+    type: gauge
+  - prom_name: getPumpeTankStatus
+    mqtt_name: getPumpeTankStatus
+    help: current power
+    type: gauge
+  - prom_name: getPumpeZStatus
+    mqtt_name: getPumpeZStatus
+    help: current power
+    type: gauge

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,12 +2,12 @@ package config
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"regexp"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -87,6 +87,8 @@ func MustNewRegexp(pattern string) *Regexp {
 }
 
 type Config struct {
+	Interface   string             `yaml:"interface"`
+	Port        string             `yaml:"port"`
 	JsonParsing *JsonParsingConfig `yaml:"json_parsing,omitempty"`
 	Metrics     []MetricConfig     `yaml:"metrics"`
 	MQTT        *MQTTConfig        `yaml:"mqtt,omitempty"`

--- a/pkg/metrics/ingest.go
+++ b/pkg/metrics/ingest.go
@@ -11,12 +11,12 @@ import (
 type Ingest struct {
 	instrumentation
 	extractor     Extractor
-	deviceIDRegex *config.Regexp
+	deviceIDRegex []*config.Regexp
 	collector     Collector
 	logger        *zap.Logger
 }
 
-func NewIngest(collector Collector, extractor Extractor, deviceIDRegex *config.Regexp) *Ingest {
+func NewIngest(collector Collector, extractor Extractor, deviceIDRegex []*config.Regexp) *Ingest {
 
 	return &Ingest{
 		instrumentation: defaultInstrumentation,
@@ -52,5 +52,10 @@ func (i *Ingest) SetupSubscriptionHandler(errChan chan<- error) mqtt.MessageHand
 
 // deviceID uses the configured DeviceIDRegex to extract the device ID from the given mqtt topic path.
 func (i *Ingest) deviceID(topic string) string {
-	return i.deviceIDRegex.GroupValue(topic, config.DeviceIDRegexGroup)
+	for _, deviceIDRegex := range i.deviceIDRegex {
+		if deviceIDRegex.Match(topic) {
+			return deviceIDRegex.GroupValue(topic, config.DeviceIDRegexGroup)
+		}
+	}
+	return ""
 }

--- a/pkg/mqttclient/mqttClient.go
+++ b/pkg/mqttclient/mqttClient.go
@@ -6,7 +6,7 @@ import (
 )
 
 type SubscribeOptions struct {
-	Topic             string
+	Topic             []string
 	QoS               byte
 	OnMessageReceived mqtt.MessageHandler
 	Logger            *zap.Logger
@@ -18,9 +18,11 @@ func Subscribe(connectionOptions *mqtt.ClientOptions, subscribeOptions Subscribe
 		logger := subscribeOptions.Logger
 		oldConnect(client)
 		logger.Info("Connected to MQTT Broker")
-		logger.Info("Will subscribe to topic", zap.String("topic", subscribeOptions.Topic))
-		if token := client.Subscribe(subscribeOptions.Topic, subscribeOptions.QoS, subscribeOptions.OnMessageReceived); token.Wait() && token.Error() != nil {
-			logger.Error("Could not subscribe", zap.Error(token.Error()))
+		for _, topic := range subscribeOptions.Topic {
+			logger.Info("Will subscribe to topic", zap.String("topic", topic))
+			if token := client.Subscribe(topic, subscribeOptions.QoS, subscribeOptions.OnMessageReceived); token.Wait() && token.Error() != nil {
+				logger.Error("Could not subscribe", zap.Error(token.Error()))
+			}
 		}
 	}
 	client := mqtt.NewClient(connectionOptions)


### PR DESCRIPTION
To strip any default metrics provided by the GO prometheus library, I used a clean registry.