### PR TITLE
Update Readme.md: object_per_topic_config: encoding need to be upper case

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -170,7 +170,7 @@ mqtt:
  # This is the default. 
  object_per_topic_config:
   # The encoding of the object, currently only json is supported
-  encoding: json
+  encoding: JSON
 cache:
  # Timeout. Each received metric will be presented for this time if no update is send via MQTT.
  # Set the timeout to -1 to disable the deletion of metrics from the cache. The exporter presents the ingest timestamp


### PR DESCRIPTION
JSON needs to be upper case, otherwiese "could not setup a metric extractor {"error": "unsupported object format: json"} " is thrown.