### PR TITLE
Handle json payload in metric_per_topic mode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,6 +71,12 @@ E.g let's assume the following MQTT JSON message:
 We can now set `json_parsing.seperator` to `/`. This allows us to specify `mqtt_name` as `computed/heat.index`. Keep in mind, 
 `json_parsing.seperator` is a global setting. This affects all `mqtt_name` fields in your configuration.
 
+Some devices like Shelly Plus H&T publish one metric per-topic in a JSON format:
+```
+shellies/shellyplusht-xxx/status/humidity:0 {"id": 0,"rh":51.9}
+```
+You can use PayloadField to extract the desired value.
+
 ### Tasmota
 An example configuration for the tasmota based Gosund SP111 device is given in [examples/gosund_sp111.yaml](examples/gosund_sp111.yaml).
 

--- a/hack/shellyplusht.yaml
+++ b/hack/shellyplusht.yaml
@@ -1,0 +1,22 @@
+mqtt:
+  server: tcp://mosquitto:1883
+  topic_path: shellies/+/sensor/+
+  device_id_regex: "shellies/(?P<deviceid>.*)/sensor"
+  metric_per_topic_config:
+    metric_name_regex: "shellies/(?P<deviceid>.*)/sensor/(?P<metricname>.*)"
+  qos: 0
+cache:
+  timeout: 24h
+metrics:
+  - prom_name: temperature
+    # The name of the metric in a MQTT JSON message
+    mqtt_name: status/temperature:0
+    # The field to extract in JSON payload
+    PayloadField: rh
+    # The prometheus help text for this metric
+    help: shelly temperature reading
+    # The prometheus type for this metric. Valid values are: "gauge" and "counter"
+    type: gauge
+    # A map of string to string for constant labels. This labels will be attached to every prometheus metric
+    const_labels:
+      sensor_type: shellyplusht

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -130,6 +130,7 @@ type MetricPerTopicConfig struct {
 type MetricConfig struct {
 	PrometheusName     string                    `yaml:"prom_name"`
 	MQTTName           string                    `yaml:"mqtt_name"`
+	PayloadField       string                    `yaml:"payload_field"`
 	SensorNameFilter   Regexp                    `yaml:"sensor_name_filter"`
 	Help               string                    `yaml:"help"`
 	ValueType          string                    `yaml:"type"`


### PR DESCRIPTION
Hello

I try to use your exporter to scrap Shelly Plus H&T sensor metrics.
This device tends to use a metric per topic and sends some metrics in json format:

shellies/shellyplusht-xxx/status/humidity:0 {"id": 0,"rh":51.9}
shellies/shellyplusht-xxx/status/temperature:0 {"id": 0,"tC":22.4, "tF":72.3}

Thanks.