### PR TITLE
feat: Add configuration option to enable/disable profiling metrics

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -19,6 +19,10 @@ mqtt:
   # device_id_regex: "(.*/)?(?P<deviceid>.*)"
   # The MQTT QoS level
   qos: 0
+# Export internal profiling metrics including CPU, Memory, uptime, open file
+# descriptors, as well as metrics exported by Go runtime such as information about
+# heap and garbage collection stats.
+enable_profiling_metrics: false
 cache:
   # Timeout. Each received metric will be presented for this time if no update is send via MQTT.
   # Set the timeout to -1 to disable the deletion of metrics from the cache. The exporter presents the ingest timestamp

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,10 +89,11 @@ func MustNewRegexp(pattern string) *Regexp {
 }
 
 type Config struct {
-	JsonParsing *JsonParsingConfig `yaml:"json_parsing,omitempty"`
-	Metrics     []MetricConfig     `yaml:"metrics"`
-	MQTT        *MQTTConfig        `yaml:"mqtt,omitempty"`
-	Cache       *CacheConfig       `yaml:"cache,omitempty"`
+	JsonParsing     *JsonParsingConfig `yaml:"json_parsing,omitempty"`
+	Metrics         []MetricConfig     `yaml:"metrics"`
+	MQTT            *MQTTConfig        `yaml:"mqtt,omitempty"`
+	Cache           *CacheConfig       `yaml:"cache,omitempty"`
+	EnableProfiling bool               `yaml:"enable_profiling_metrics,omitempty"`
 }
 
 type CacheConfig struct {


### PR DESCRIPTION
Added a new configuration `enable_profiling_metrics` which enable/disable the default runtime metrics exported by the Prometheus client package.

BREAKING CHANGE: Changed default behavior to exclude runtime metrics.
        Enable with enable_profiling_metrics configuration option.