### PR TITLE
make error_value global to metric and add error_expression

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -241,15 +241,15 @@ metrics:
   # A map of string to string for constant labels. This labels will be attached to every prometheus metric
    const_labels:
     sensor_type: ikea
+  # When specified, metric value to use if a value cannot be parsed (match cannot be found in the map above, invalid float parsing, expression fails, ...)
+  # If not specified, parsing error will occur.
+  error_value: 1
   # When specified, enables mapping between string values to metric values.
    string_value_mapping:
     # A map of string to metric value.
     map:
      off: 0
      low: 0
-    # Metric value to use if a match cannot be found in the map above.
-    # If not specified, parsing error will occur.
-    error_value: 1
   # The name of the metric in prometheus
  - prom_name: total_light_usage_seconds
   # The name of the metric in a MQTT JSON message
@@ -265,15 +265,15 @@ metrics:
   # A map of string to string for constant labels. This labels will be attached to every prometheus metric
    const_labels:
     sensor_type: ikea
+  # Metric value to use if a value cannot be parsed (match cannot be found in the map above, invalid float parsing, ...)
+  # If not specified, parsing error will occur.
+  error_value: 1
   # When specified, enables mapping between string values to metric values.
    string_value_mapping:
     # A map of string to metric value.
     map:
      off: 0
      low: 0
-    # Metric value to use if a match cannot be found in the map above.
-    # If not specified, parsing error will occur.
-    error_value: 1
   # Sum up the time the light is on, see the section "Expressions" below.
   expression: "value > 0 ? last_result + elapsed.Seconds() : last_result"
   # The name of the metric in prometheus

--- a/cmd/mqtt2prometheus.go
+++ b/cmd/mqtt2prometheus.go
@@ -80,7 +80,7 @@ func main() {
 	logger := mustSetupLogger()
 	defer logger.Sync() //nolint:errcheck
 	c := make(chan os.Signal, 1)
-	cfg, err := config.LoadConfig(*configFlag)
+	cfg, err := config.LoadConfig(*configFlag, logger)
 	if err != nil {
 		logger.Fatal("Could not load config", zap.Error(err))
 	}

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -81,12 +81,12 @@ metrics:
     # A map of string to string for constant labels. This labels will be attached to every prometheus metric
     const_labels:
       sensor_type: ikea
+    # Metric value to use if a value cannot be parsed (match cannot be found in the map above, invalid float parsing, ...)
+    # If not specified, parsing error will occur.
+    error_value: 1
     # When specified, enables mapping between string values to metric values.
     string_value_mapping:
       # A map of string to metric value.
       map:
         off: 0
         low: 0
-      # Metric value to use if a match cannot be found in the map above.
-      # If not specified, parsing error will occur.
-      error_value: 1

--- a/fuzzing/json_per_topic/fuzz.go
+++ b/fuzzing/json_per_topic/fuzz.go
@@ -16,8 +16,8 @@ func Fuzz(data []byte) int {
 		{
 			PrometheusName: "enabled",
 			ValueType:      "gauge",
+			ErrorValue: floatP(12333),
 			StringValueMapping: &config.StringValueMappingConfig{
-				ErrorValue: floatP(12333),
 				Map: map[string]float64{
 					"foo": 112,
 					"bar": 2,

--- a/fuzzing/metric_per_topic/fuzz.go
+++ b/fuzzing/metric_per_topic/fuzz.go
@@ -17,8 +17,8 @@ func Fuzz(data []byte) int {
 		{
 			PrometheusName: "enabled",
 			ValueType:      "gauge",
+			ErrorValue: floatP(12333),
 			StringValueMapping: &config.StringValueMappingConfig{
-				ErrorValue: floatP(12333),
 				Map: map[string]float64{
 					"foo": 112,
 					"bar": 2,

--- a/hack/dht22.yaml
+++ b/hack/dht22.yaml
@@ -57,12 +57,12 @@ metrics:
     # A map of string to string for constant labels. This labels will be attached to every prometheus metric
     const_labels:
       sensor_type: ikea
+    # Metric value to use if a value cannot be parsed (match cannot be found in the map above, invalid float parsing, ...)
+    # If not specified, parsing error will occur.
+    error_value: 1
     # When specified, enables mapping between string values to metric values.
     string_value_mapping:
       # A map of string to metric value.
       map:
         off: 0
         low: 0
-      # Metric value to use if a match cannot be found in the map above.
-      # If not specified, parsing error will occur.
-      error_value: 1

--- a/pkg/metrics/parser_test.go
+++ b/pkg/metrics/parser_test.go
@@ -39,6 +39,9 @@ func TestParser_parseMetric(t *testing.T) {
 		deviceID   string
 		value      interface{}
 	}
+
+	var errorValue float64 = 42.44
+
 	tests := []struct {
 		name      string
 		fields    fields
@@ -142,6 +145,32 @@ func TestParser_parseMetric(t *testing.T) {
 				value:      "12.6.5",
 			},
 			wantErr: true,
+		},
+		{
+			name: "string value failure with errorValue",
+			fields: fields{
+				map[string][]*config.MetricConfig{
+					"temperature": {
+						{
+							PrometheusName: "temperature",
+							ValueType:      "gauge",
+							ErrorValue:     &errorValue,
+						},
+					},
+				},
+			},
+			args: args{
+				metricPath: "temperature",
+				deviceID:   "dht22",
+				value:      "12.6.5",
+			},
+			want: Metric{
+				Description: prometheus.NewDesc("temperature", "", []string{"sensor", "topic"}, nil),
+				ValueType:   prometheus.GaugeValue,
+				Value:       errorValue,
+				IngestTime:  testNow(),
+				Topic:       "",
+			},
 		},
 		{
 			name: "float value",
@@ -335,8 +364,8 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "enabled",
 							ValueType:      "gauge",
+							ErrorValue: floatP(12333),
 							StringValueMapping: &config.StringValueMappingConfig{
-								ErrorValue: floatP(12333),
 								Map: map[string]float64{
 									"foo": 112,
 									"bar": 2,
@@ -392,8 +421,8 @@ func TestParser_parseMetric(t *testing.T) {
 						{
 							PrometheusName: "enabled",
 							ValueType:      "gauge",
+							ErrorValue: floatP(12333),
 							StringValueMapping: &config.StringValueMappingConfig{
-								ErrorValue: floatP(12333),
 								Map: map[string]float64{
 									"foo": 112,
 									"bar": 2,
@@ -419,7 +448,6 @@ func TestParser_parseMetric(t *testing.T) {
 							PrometheusName: "enabled",
 							ValueType:      "gauge",
 							StringValueMapping: &config.StringValueMappingConfig{
-								ErrorValue: floatP(12333),
 								Map: map[string]float64{
 									"foo": 112,
 									"bar": 2,


### PR DESCRIPTION
in order to better handle errors in config metric:
- move `string_mapping_value.error_value` to upper level
- mark `string_mapping_value.error_value` as deprecated

if there's an error during type conversion or during execution of `expression` then `error_value` is returned (if set, otherwise an error is thrown and no metric is sent)