### PR TITLE
add raw_expression

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -140,6 +140,7 @@ type MetricConfig struct {
 	Help               string                    `yaml:"help"`
 	ValueType          string                    `yaml:"type"`
 	OmitTimestamp      bool                      `yaml:"omit_timestamp"`
+	RawExpression      string                    `yaml:"raw_expression"`
 	Expression         string                    `yaml:"expression"`
 	ForceMonotonicy    bool                      `yaml:"force_monotonicy"`
 	ConstantLabels     map[string]string         `yaml:"const_labels"`
@@ -242,6 +243,10 @@ func LoadConfig(configFile string, logger *zap.Logger) (Config, error) {
 				return Config{}, fmt.Errorf("metric %s/%s: cannot set both string_value_mapping.error_value and error_value (string_value_mapping.error_value is deprecated).", m.MQTTName, m.PrometheusName)
 			}
 			logger.Warn("string_value_mapping.error_value is deprecated: please use error_value at the metric level.", zap.String("prometheusName", m.PrometheusName), zap.String("MQTTName", m.MQTTName))
+		}
+
+		if m.Expression != "" && m.RawExpression != ""  {
+			return Config{}, fmt.Errorf("metric %s/%s: expression and raw_expression are mutually exclusive.", m.MQTTName, m.PrometheusName)
 		}
 	}
 	if forcesMonotonicy {


### PR DESCRIPTION
add `raw_expression` in metric config in order to handle dynamic string MQTT values. It runs without type conversion while `expression`does.

here is a use case: a MQTT metric returned a string with the current datetime using the format H20241227104456 and it would be nice to be able to convert this to the corresponding unix time() to make it a prometheus valid value. Currently mqtt2prometheus is not able to handle this usecase.

With `raw_expression`, I would set the following:
```yaml
raw_expression: 'date(string(raw_value), "H060102150405", "Europe/Paris").Unix()'
```

Note: this PR must be merged after #157 and after #161