### PR TITLE
Add Qingping Air Monitor Lite example

### DIFF
--- a/examples/qingping.yaml
+++ b/examples/qingping.yaml
@@ -1,0 +1,36 @@
+# Qingping Air Monitor Lite
+# https://developer.qingping.co/private/communication-protocols/public-mqtt-json
+
+mqtt:
+  server: tcp://127.0.0.1:1883
+  user: bob
+  password: happylittleclouds
+  topic_path: qingping/+/up
+  device_id_regex: "/(?P<deviceid>.+)/up$"
+  qos: 0
+cache:
+  timeout: 24h
+json_parsing:
+  separator: .
+metrics:
+  - prom_name: qp_timestamp
+    mqtt_name: 'sensorData.[0].timestamp.value'
+    type: gauge
+  - prom_name: qp_temperature
+    mqtt_name: 'sensorData.[0].temperature.value'
+    type: gauge
+  - prom_name: qp_humidity
+    mqtt_name: 'sensorData.[0].humidity.value'
+    type: gauge
+  - prom_name: qp_co2
+    mqtt_name: 'sensorData.[0].co2.value'
+    type: gauge
+  - prom_name: qp_pm25
+    mqtt_name: 'sensorData.[0].pm25.value'
+    type: gauge
+  - prom_name: qp_pm10
+    mqtt_name: 'sensorData.[0].pm10.value'
+    type: gauge
+  - prom_name: qp_battery
+    mqtt_name: 'sensorData.[0].battery.value'
+    type: gauge


### PR DESCRIPTION
The Qingping data format is quite hard to guess, because of an array in the middle:

```json
{
  "type": "17",
  "id": 641,
  "need_ack": 0,
  "mac": "**REDACTED**",
  "timestamp": 1748860948,
  "sensorData": [
    {
      "timestamp": { "value": 1748860920 },
      "temperature": { "value": 25.72 },
      "humidity": { "value": 40.39 },
      "co2": { "value": 570 },
      "pm25": { "value": 168 },
      "pm10": { "value": 170 },
      "battery": { "value": 100 }
    }
  ]
}
```

I spent several hours debugging until I notices that `sensorData` is an array. 

The sensor is quite popular, and there's a verdor-supported MQTT integration, so I believe it should be present ad an example.