### PR TITLE
Install systemd unit to /usr/lib

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -84,7 +84,7 @@ nfpms:
         dst: /etc/mqtt2prometheus/config.yaml
         type: config
       - src: ./systemd/mqtt2prometheus.service
-        dst: /etc/systemd/system/mqtt2prometheus.service
+        dst: /usr/lib/systemd/system/mqtt2prometheus.service
         type: config
       - src: ./systemd/mqtt2prometheus
         dst: /etc/default/mqtt2prometheus


### PR DESCRIPTION
Package provided systemd units go in `/usr/lib/`, not in `/etc`. See man systemd.unit, section "UNIT FILE LOAD PATH".