### PR TITLE
provide payload to label and value expressions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -354,9 +354,13 @@ Expression is a peace of code that is run dynamically for calculate metric value
 
 #### Metric value
 Metric values can be derived from sensor inputs using complex expressions. Set the metric config option `raw_expression` or `expression` to the desired formular to calculate the result from the input. `raw_expression` and `expression` are mutually exclusives:
-* `raw_expression` is run without raw value conversion. It's `raw_expression` duty to handle the conversion. Only `raw_value` is set while `value` is always set to 0.0. Here is an example which convert datetime (format `HYYMMDDhhmmss`) to unix timestamp:
+* `raw_expression` is run without raw value conversion. It's `raw_expression` duty to handle the conversion. Only `raw_value` is set while `value` is always set to 0.0. The full `payload` map is also available. Here is an example which converts a datetime (format `HYYMMDDhhmmss`) to a unix timestamp:
 ```yaml
 raw_expression: 'date(string(raw_value), "H060102150405", "Europe/Paris").Unix()'
+```
+You can also use `payload` to pull a sibling field directly:
+```yaml
+raw_expression: 'float(payload["humidity"])'
 ```
 * `expression` is run after raw value conversion. If conversion fails, `expression` is not run. Here's an example which integrates all positive values over time:
 ```yaml
@@ -365,7 +369,17 @@ expression: "value > 0 ? last_result + value * elapsed.Seconds() : last_result"
 
 #### Dynamic labels
 Dynamic labels are derivated from sensor inputs using complex expressions. Define labels and the corresponding expression in the metric config otpion `dynamic_labels`.
-`raw_value` and `value` are both set in this context. The value returned from dynamic labels expression is not typed and will be converted to string before being exported.
+`raw_value`, `value`, and `payload` are all set in this context. The value returned from dynamic labels expression is not typed and will be converted to string before being exported.
+
+For example, if a sensor publishes `{"temperature": 21.0, "unit": "celsius"}` you can promote `unit` to a prometheus label:
+```yaml
+- prom_name: temperature
+  mqtt_name: temperature
+  type: gauge
+  dynamic_labels:
+    unit: 'string(payload["unit"])'
+```
+This produces `temperature{sensor="...",topic="...",unit="celsius"} 21.0`.
 
 #### Expression
 During the evaluation, the following variables are available to the expression:
@@ -374,6 +388,7 @@ During the evaluation, the following variables are available to the expression:
 * `last_value` - the `value` during the previous expression evaluation
 * `last_result` - the result from the previous expression evaluation (a float for `raw_expression`/`expression`, a string for `dynamic_labels`)
 * `elapsed` - the time that passed since the previous evaluation, as a [Duration](https://pkg.go.dev/time#Duration) value
+* `payload` - the full MQTT JSON payload as a `map[string]interface{}`, allowing access to sibling fields not targeted by `mqtt_name`
 
 The [language definition](https://expr-lang.org/docs/v1.9/Language-Definition) describes the expression syntax. In addition, the following functions are available:
 * `now()` - the current time as a [Time](https://pkg.go.dev/time#Time) value

--- a/pkg/metrics/extractor.go
+++ b/pkg/metrics/extractor.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 
@@ -23,7 +24,11 @@ func metricID(topic, metric, deviceID, promName string) string {
 func NewJSONObjectExtractor(p Parser) Extractor {
 	return func(topic string, payload []byte, deviceID string) (MetricCollection, error) {
 		var mc MetricCollection
-		parsed := gojsonq.New(gojsonq.SetSeparator(p.separator)).FromString(string(payload))
+		var jsonPayload map[string]interface{}
+		if err := json.Unmarshal(payload, &jsonPayload); err != nil {
+			jsonPayload = map[string]interface{}{}
+		}
+		parsed := gojsonq.New(gojsonq.SetSeparator(p.separator)).FromInterface(jsonPayload)
 
 		for path := range p.config() {
 			rawValue := parsed.Find(path)
@@ -35,7 +40,7 @@ func NewJSONObjectExtractor(p Parser) Extractor {
 			// Find all valid metric configs
 			for _, config := range p.findMetricConfigs(path, deviceID) {
 				id := metricID(topic, path, deviceID, config.PrometheusName)
-				m, err := p.parseMetric(config, id, rawValue)
+				m, err := p.parseMetric(config, id, rawValue, jsonPayload)
 				if err != nil {
 					return nil, fmt.Errorf("failed to parse valid value from '%v' for metric %q: %w", rawValue, config.PrometheusName, err)
 				}
@@ -58,6 +63,7 @@ func NewMetricPerTopicExtractor(p Parser, metricNameRegex *config.Regexp) Extrac
 		// Find all valid metric configs
 		for _, config := range p.findMetricConfigs(metricName, deviceID) {
 			var rawValue interface{}
+			var jsonPayload map[string]interface{}
 			if config.PayloadField != "" {
 				parsed := gojsonq.New(gojsonq.SetSeparator(p.separator)).FromString(string(payload))
 				rawValue = parsed.Find(config.PayloadField)
@@ -65,12 +71,16 @@ func NewMetricPerTopicExtractor(p Parser, metricNameRegex *config.Regexp) Extrac
 				if rawValue == nil {
 					return nil, fmt.Errorf("failed to extract field %q from payload %q for metric %q", config.PayloadField, payload, metricName)
 				}
+				if err := json.Unmarshal(payload, &jsonPayload); err != nil {
+					jsonPayload = map[string]interface{}{}
+				}
 			} else {
 				rawValue = string(payload)
+				jsonPayload = map[string]interface{}{}
 			}
 
 			id := metricID(topic, metricName, deviceID, config.PrometheusName)
-			m, err := p.parseMetric(config, id, rawValue)
+			m, err := p.parseMetric(config, id, rawValue, jsonPayload)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse valid value from '%v' for metric %q: %w", rawValue, config.PrometheusName, err)
 			}

--- a/pkg/metrics/extractor_test.go
+++ b/pkg/metrics/extractor_test.go
@@ -129,12 +129,44 @@ func TestNewJSONObjectExtractor_parseMetric(t *testing.T) {
 			want:    Metric{},
 			noValue: true,
 		},
+		{
+			name:      "dynamic label accesses payload field",
+			separator: ".",
+			fields: fields{
+				map[string][]*config.MetricConfig{
+					"temperature": {
+						{
+							PrometheusName: "temperature",
+							MQTTName:       "temperature",
+							ValueType:      "gauge",
+							DynamicLabels:  map[string]string{"unit": `string(payload["unit"])`},
+						},
+					},
+				},
+			},
+			args: args{
+				metricPath: "topic",
+				deviceID:   "dht22",
+				value:      `{"temperature": 21.0, "unit": "celsius"}`,
+			},
+			want: Metric{
+				Description: prometheus.NewDesc("temperature", "", []string{"sensor", "topic", "unit"}, nil),
+				ValueType:   prometheus.GaugeValue,
+				Value:       21.0,
+				IngestTime:  testNow(),
+				Topic:       "topic",
+				Labels:      map[string]string{"unit": "celsius"},
+				LabelsKeys:  []string{"unit"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Parser{
 				separator:     tt.separator,
 				metricConfigs: tt.fields.metricConfigs,
+				stateDir:      t.TempDir(),
+				states:        make(map[string]*metricState),
 			}
 			extractor := NewJSONObjectExtractor(p)
 

--- a/pkg/metrics/parser.go
+++ b/pkg/metrics/parser.go
@@ -72,6 +72,7 @@ const (
 	env_abs            = "abs"
 	env_min            = "min"
 	env_max            = "max"
+	env_payload        = "payload"
 )
 
 var now = time.Now
@@ -135,6 +136,7 @@ func defaultExprEnv() map[string]interface{} {
 		env_last_value:  0.0,
 		env_last_result: 0.0,
 		env_elapsed:     time.Duration(0),
+		env_payload:     map[string]interface{}{},
 		// Functions
 		env_now:   now,
 		env_int:   toInt64,
@@ -180,12 +182,12 @@ func (p *Parser) findMetricConfigs(metric string, deviceID string) []*config.Met
 
 // parseMetric parses the given value according to the given deviceID and metricPath. The config allows to
 // parse a metric value according to the device ID.
-func (p *Parser) parseMetric(cfg *config.MetricConfig, metricID string, value interface{}) (Metric, error) {
+func (p *Parser) parseMetric(cfg *config.MetricConfig, metricID string, value interface{}, jsonPayload map[string]interface{}) (Metric, error) {
 	var metricValue float64
 	var err error
 
 	if cfg.RawExpression != "" {
-		if metricValue, err = p.evalExpressionValue(metricID, cfg.RawExpression, value, metricValue); err != nil {
+		if metricValue, err = p.evalExpressionValue(metricID, cfg.RawExpression, value, metricValue, jsonPayload); err != nil {
 			if cfg.ErrorValue != nil {
 				metricValue = *cfg.ErrorValue
 			} else {
@@ -243,7 +245,7 @@ func (p *Parser) parseMetric(cfg *config.MetricConfig, metricID string, value in
 		}
 
 		if cfg.Expression != "" {
-			if metricValue, err = p.evalExpressionValue(metricID, cfg.Expression, value, metricValue); err != nil {
+			if metricValue, err = p.evalExpressionValue(metricID, cfg.Expression, value, metricValue, jsonPayload); err != nil {
 				if cfg.ErrorValue != nil {
 					metricValue = *cfg.ErrorValue
 				} else {
@@ -277,7 +279,7 @@ func (p *Parser) parseMetric(cfg *config.MetricConfig, metricID string, value in
 	if len(cfg.DynamicLabels) > 0 {
 		labels = make(map[string]string, len(cfg.DynamicLabels))
 		for k, v := range cfg.DynamicLabels {
-			value, err := p.evalExpressionLabel(metricID, k, v, value, metricValue)
+			value, err := p.evalExpressionLabel(metricID, k, v, value, metricValue, jsonPayload)
 			if err != nil {
 				return Metric{}, err
 			}
@@ -347,6 +349,9 @@ func (p *Parser) writeMetricState(metricID string, state *metricState) error {
 // The state is read from and written back to disk as needed.
 func (p *Parser) getMetricState(metricID string) (*metricState, error) {
 	var err error
+	if p.states == nil {
+		p.states = make(map[string]*metricState)
+	}
 	state, found := p.states[metricID]
 	if !found {
 		if state, err = p.readMetricState(metricID); err != nil {
@@ -383,7 +388,7 @@ func (p *Parser) enforceMonotonicy(metricID string, value float64) (float64, err
 
 // evalExpressionValue runs the given code in the metric's environment and returns the result.
 // In case of an error, the original value is returned.
-func (p *Parser) evalExpressionValue(metricID, code string, raw_value interface{}, value float64) (float64, error) {
+func (p *Parser) evalExpressionValue(metricID, code string, raw_value interface{}, value float64, jsonPayload map[string]interface{}) (float64, error) {
 	ms, err := p.getMetricState(metricID)
 	if err != nil {
 		return value, err
@@ -409,6 +414,7 @@ func (p *Parser) evalExpressionValue(metricID, code string, raw_value interface{
 	} else {
 		ms.env[env_elapsed] = now().Sub(ms.dynamic.LastExprTimestamp)
 	}
+	ms.env[env_payload] = jsonPayload
 
 	result, err := expr.Run(ms.program, ms.env)
 	if err != nil {
@@ -428,7 +434,7 @@ func (p *Parser) evalExpressionValue(metricID, code string, raw_value interface{
 
 // evalExpressionLabel runs the given code in the metric's environment and returns the result.
 // In case of an error, the original value is returned.
-func (p *Parser) evalExpressionLabel(metricID, label, code string, rawValue interface{}, value float64) (string, error) {
+func (p *Parser) evalExpressionLabel(metricID, label, code string, rawValue interface{}, value float64, jsonPayload map[string]interface{}) (string, error) {
 	ms, err := p.getMetricState(label + "@" + metricID)
 	if err != nil {
 		return "", err
@@ -454,6 +460,7 @@ func (p *Parser) evalExpressionLabel(metricID, label, code string, rawValue inte
 	} else {
 		ms.env[env_elapsed] = now().Sub(ms.dynamic.LastExprTimestamp)
 	}
+	ms.env[env_payload] = jsonPayload
 
 	result, err := expr.Run(ms.program, ms.env)
 	if err != nil {

--- a/pkg/metrics/parser_test.go
+++ b/pkg/metrics/parser_test.go
@@ -35,9 +35,10 @@ func TestParser_parseMetric(t *testing.T) {
 		metricConfigs map[string][]*config.MetricConfig
 	}
 	type args struct {
-		metricPath string
-		deviceID   string
-		value      interface{}
+		metricPath  string
+		deviceID    string
+		value       interface{}
+		jsonPayload map[string]interface{}
 	}
 
 	var errorValue float64 = 42.44
@@ -721,6 +722,60 @@ func TestParser_parseMetric(t *testing.T) {
 				Value:       42.44,
 			},
 		},
+		{
+			name: "dynamic label from payload field",
+			fields: fields{
+				map[string][]*config.MetricConfig{
+					"temperature": {
+						{
+							PrometheusName: "temperature",
+							ValueType:      "gauge",
+							OmitTimestamp:  true,
+							DynamicLabels:  map[string]string{"unit": `string(payload["unit"])`},
+						},
+					},
+				},
+			},
+			args: args{
+				metricPath:  "temperature",
+				deviceID:    "dht22",
+				value:       22.5,
+				jsonPayload: map[string]interface{}{"temperature": 22.5, "unit": "celsius"},
+			},
+			want: Metric{
+				Description: prometheus.NewDesc("temperature", "", []string{"sensor", "topic", "unit"}, nil),
+				ValueType:   prometheus.GaugeValue,
+				Value:       22.5,
+				Labels:      map[string]string{"unit": "celsius"},
+				LabelsKeys:  []string{"unit"},
+			},
+		},
+		{
+			name: "raw expression reads sibling payload field",
+			fields: fields{
+				map[string][]*config.MetricConfig{
+					"humidity": {
+						{
+							PrometheusName: "humidity",
+							ValueType:      "gauge",
+							OmitTimestamp:  true,
+							RawExpression:  `float(payload["humidity"])`,
+						},
+					},
+				},
+			},
+			args: args{
+				metricPath:  "humidity",
+				deviceID:    "dht22",
+				value:       nil,
+				jsonPayload: map[string]interface{}{"temperature": 22.5, "humidity": 55.0},
+			},
+			want: Metric{
+				Description: prometheus.NewDesc("humidity", "", []string{"sensor", "topic"}, nil),
+				ValueType:   prometheus.GaugeValue,
+				Value:       55.0,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -741,7 +796,7 @@ func TestParser_parseMetric(t *testing.T) {
 			config := configs[0]
 
 			id := metricID("", tt.args.metricPath, tt.args.deviceID, config.PrometheusName)
-			got, err := p.parseMetric(config, id, tt.args.value)
+			got, err := p.parseMetric(config, id, tt.args.value, tt.args.jsonPayload)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseMetric() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -851,7 +906,7 @@ func TestParser_evalExpression(t *testing.T) {
 
 			p := NewParser(nil, ".", stateDir)
 			for i, value := range tt.values {
-				got, err := p.evalExpressionValue(id, tt.expression, value, value)
+				got, err := p.evalExpressionValue(id, tt.expression, value, value, nil)
 				want := tt.results[i]
 				if err != nil {
 					t.Errorf("evaluating the %dth value '%v' failed: %v", i, value, err)


### PR DESCRIPTION
Alternative way to implement #74 without adding new configuration slots, but provides "payload" as a variable to be referenced in expressions. ie `dynamic_labels: unit: string(payload["unit"])`